### PR TITLE
Fix various a11y issues

### DIFF
--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -52,7 +52,7 @@
 	</svelte:fragment>
 </Nav>
 
-<main><slot /></main>
+<main id="main"><slot /></main>
 
 <style>
 	:global(body) {

--- a/src/routes/tutorial/[slug]/_/Menu/Menu.svelte
+++ b/src/routes/tutorial/[slug]/_/Menu/Menu.svelte
@@ -49,9 +49,13 @@
 	}
 </script>
 
-<nav class:open={is_open}>
+<button class="menu-toggle" on:click={() => (is_open = !is_open)} aria-label="Toggle menu" aria-expanded={is_open}>
+	<Icon name={is_open ? 'close' : 'menu'} />
+</button>
+
+<nav class:open={is_open} aria-label="tutorial sections">
 	<div class="controls">
-		<input type="search" placeholder="Search" bind:value={search} />
+		<input type="search" placeholder="Search" bind:value={search} aria-hidden={!is_open ? "true" : null} tabindex={!is_open ? -1 : null} />
 	</div>
 
 	<div class="sections">
@@ -101,10 +105,6 @@
 		</ul>
 	</div>
 </nav>
-
-<button class="menu-toggle" on:click={() => (is_open = !is_open)} aria-label="Toggle menu">
-	<Icon name={is_open ? 'close' : 'menu'} />
-</button>
 
 <style>
 	nav {
@@ -164,7 +164,7 @@
 		top: 0;
 		width: var(--menu-width);
 		height: var(--menu-width);
-		z-index: 2;
+		z-index: 3;
 		/* background: linear-gradient(
 			to right,
 			var(--second),

--- a/src/routes/tutorial/[slug]/index.svelte
+++ b/src/routes/tutorial/[slug]/index.svelte
@@ -172,16 +172,20 @@
 
 <svelte:window on:message={handle_message} />
 
+<svelte:head>
+	<title>{section.chapter.title} / {section.title} • Svelte Tutorial</title>
+</svelte:head>
+
 <div class="container">
 	<SplitPane type="horizontal" min="360px" max="50%" pos="480px">
 		<section class="content" slot="a">
 			<Menu bind:this={menu} {index} current={section} />
 
 			<header on:click={() => menu.open()}>
-				<span>
+				<h1>
 					Part {section.part.index + 1} > {section.chapter.title} >
 					<strong>{section.title}</strong>
-				</span>
+				</h1>
 			</header>
 
 			<div class="text">
@@ -278,6 +282,7 @@
 						</button>
 
 						<input
+							aria-label="URL"
 							value={path}
 							on:change={(e) => {
 								const url = new URL(e.currentTarget.value, adapter.base);
@@ -320,7 +325,7 @@
 	}
 
 	header strong,
-	header span {
+	header h1 {
 		font-size: 1.4rem;
 	}
 
@@ -328,11 +333,12 @@
 		color: hsl(240, 8%, 94%);
 	}
 
-	header span {
+	header h1 {
 		color: hsl(240, 8%, 84%);
 		white-space: nowrap;
 		text-overflow: ellipsis;
 		overflow: hidden;
+		font-weight: 400;
 	}
 
 	.text {


### PR DESCRIPTION
- The skip link was linking to "#main", but there wasn't an element with that ID to link to. Added an ID to the main tag.
- Add titles to tutorial pages (important for SvelteKit's route announcer)
- Add missing h1
- Label URL input
- Improve keyboard navigation -- the menu button was _after_ the menu it opened, so after triggering it you'd have to go back to reach the menu, which is unintuitive. I moved it before the menu instead.
- Add aria-expanded to the menu button to indicate that it shows/hides content
- Add aria-hidden/tabindex=-1 to the menu's search input when the menu is closed. I would have preferred to apply `visibility: hidden` instead via CSS, but that caused the input to disappear when the menu was transitioning out. aria-hidden/tabindex should have the same effect.