### PR TITLE
inline highlights

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,7 +7,8 @@
 		{
 			"files": ["content/**/*.svelte"],
 			"options": {
-				"printWidth": 50
+				"printWidth": 50,
+				"requirePragma": true
 			}
 		}
 	]

--- a/content/tutorial/01-svelte/01-introduction/02-your-first-component/README.md
+++ b/content/tutorial/01-svelte/01-introduction/02-your-first-component/README.md
@@ -10,19 +10,18 @@ A component that just renders some static markup isn't very interesting. Let's a
 
 First, add a script tag to your component and declare a `name` variable:
 
-```diff
-+<script>
-+	let name = 'Svelte';
-+</script>
-+
+```svelte
++++<script>
+	let name = 'Svelte';
+</script>+++
+
 <h1>Hello world!</h1>
 ```
 
 Then, we can refer to `name` in the markup:
 
-```diff
--<h1>Hello world!</h1>
-+<h1>Hello {name}!</h1>
+```svelte
+<h1>Hello +++{name}+++!</h1>
 ```
 
 Inside the curly braces, we can put any JavaScript we want. Try changing `name` to `name.toUpperCase()` for a shoutier greeting.

--- a/content/tutorial/01-svelte/01-introduction/03-dynamic-attributes/README.md
+++ b/content/tutorial/01-svelte/01-introduction/03-dynamic-attributes/README.md
@@ -6,9 +6,8 @@ Just like you can use curly braces to control text, you can use them to control 
 
 Our image is missing a `src` — let's add one:
 
-```diff
--<img />
-+<img src={src} />
+```svelte
+<img +++src={src}+++ />
 ```
 
 That's better. But Svelte is giving us a warning:
@@ -19,9 +18,8 @@ When building web apps, it's important to make sure that they're _accessible_ to
 
 In this case, we're missing the `alt` attribute that describes the image for people using screenreaders, or people with slow or flaky internet connections that can't download the image. Let's add one:
 
-```diff
--<img src={src} />
-+<img src={src} alt="A man dances.">
+```svelte
+<img src={src} +++alt="A man dances."+++>
 ```
 
 We can use curly braces _inside_ attributes. Try changing it to `"{name} dances."` — remember to declare a `name` variable in the `<script>` block.
@@ -30,7 +28,6 @@ We can use curly braces _inside_ attributes. Try changing it to `"{name} dances.
 
 It's not uncommon to have an attribute where the name and value are the same, like `src={src}`. Svelte gives us a convenient shorthand for these cases:
 
-```diff
--<img src={src} alt="A man dances.">
-+<img {src} alt="A man dances.">
+```svelte
+<img +++{src}+++ alt="A man dances.">
 ```

--- a/content/tutorial/01-svelte/01-introduction/04-styling/README.md
+++ b/content/tutorial/01-svelte/01-introduction/04-styling/README.md
@@ -8,11 +8,11 @@ Just like in HTML, you can add a `<style>` tag to your component. Let's add some
 <p>This is a paragraph.</p>
 
 <style>
-	p {
++++	p {
 		color: purple;
 		font-family: 'Comic Sans MS', cursive;
 		font-size: 2em;
-	}
+	}+++
 </style>
 ```
 

--- a/content/tutorial/01-svelte/01-introduction/05-nested-components/README.md
+++ b/content/tutorial/01-svelte/01-introduction/05-nested-components/README.md
@@ -7,16 +7,16 @@ It would be impractical to put your entire app in a single component. Instead, w
 Add a `<script>` tag that imports `Nested.svelte`...
 
 ```svelte
-<script>
++++<script>
 	import Nested from './Nested.svelte';
-</script>
+</script>+++
 ```
 
 ...and include a `<Nested />` component:
 
 ```svelte
 <p>This is a paragraph.</p>
-<Nested />
++++<Nested />+++
 ```
 
 Notice that even though `Nested.svelte` has a `<p>` element, the styles from `App.svelte` don't leak in.

--- a/content/tutorial/01-svelte/01-introduction/06-html-tags/README.md
+++ b/content/tutorial/01-svelte/01-introduction/06-html-tags/README.md
@@ -9,7 +9,7 @@ But sometimes you need to render HTML directly into a component. For example, th
 In Svelte, you do this with the special `{@html ...}` tag:
 
 ```svelte
-<p>{@html string}</p>
+<p>{+++@html+++ string}</p>
 ```
 
 > Svelte doesn't perform any sanitization of the expression inside `{@html ...}` before it gets inserted into the DOM. In other words, if you use this feature it's critical that you manually escape HTML that comes from sources you don't trust, otherwise you risk exposing your users to XSS attacks.

--- a/content/tutorial/01-svelte/02-reactivity/01-reactive-assignments/README.md
+++ b/content/tutorial/01-svelte/02-reactivity/01-reactive-assignments/README.md
@@ -7,14 +7,14 @@ At the heart of Svelte is a powerful system of _reactivity_ for keeping the DOM 
 To demonstrate it, we first need to wire up an event handler (we'll learn more about these [later](/tutorial/dom-events)). Replace line 9 with this:
 
 ```svelte
-<button on:click={increment}>
+<button +++on:click={increment}+++>
 ```
 
 Inside the `increment` function, all we need to do is change the value of `count`:
 
 ```js
 function increment() {
-	count += 1;
+	+++count += 1;+++
 }
 ```
 

--- a/content/tutorial/01-svelte/02-reactivity/02-reactive-declarations/README.md
+++ b/content/tutorial/01-svelte/02-reactivity/02-reactive-declarations/README.md
@@ -8,7 +8,7 @@ For these, we have _reactive declarations_. They look like this:
 
 ```js
 let count = 0;
-$: doubled = count * 2;
++++$: doubled = count * 2;+++
 ```
 
 > Don't worry if this looks a little alien. It's [valid](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label) (if unconventional) JavaScript, which Svelte interprets to mean 're-run this code whenever any of the referenced values change'. Once you get used to it, there's no going back.
@@ -16,7 +16,9 @@ $: doubled = count * 2;
 Let's use `doubled` in our markup:
 
 ```svelte
-<p>{count} doubled is {doubled}</p>
+<button>...</button>
+
++++<p>{count} doubled is {doubled}</p>+++
 ```
 
 Of course, you could just write `{count * 2}` in the markup instead — you don't have to use reactive values. Reactive values become particularly valuable (no pun intended) when you need to reference them multiple times, or you have values that depend on _other_ reactive values.

--- a/content/tutorial/01-svelte/02-reactivity/03-reactive-statements/README.md
+++ b/content/tutorial/01-svelte/02-reactivity/03-reactive-statements/README.md
@@ -5,22 +5,24 @@ title: Statements
 We're not limited to declaring reactive _values_ — we can also run arbitrary _statements_ reactively. For example, we can log the value of `count` whenever it changes:
 
 ```js
-$: console.log('the count is ' + count);
+let count = 0;
+
++++$: console.log(`the count is ${count}`);+++
 ```
 
 You can easily group statements together with a block:
 
 ```js
-$: {
-	console.log('the count is ' + count);
-	alert('I SAID THE COUNT IS ' + count);
-}
+$: +++{+++
+	console.log(`the count is ${count}`);
+	alert(`I SAID THE COUNT IS ${count}`);
++++}+++
 ```
 
 You can even put the `$:` in front of things like `if` blocks:
 
 ```js
-$: if (count >= 10) {
+$: +++if (count >= 10)+++ {
 	alert('count is dangerously high!');
 	count = 0;
 }

--- a/content/tutorial/01-svelte/02-reactivity/04-updating-arrays-and-objects/README.md
+++ b/content/tutorial/01-svelte/02-reactivity/04-updating-arrays-and-objects/README.md
@@ -9,7 +9,7 @@ One way to fix that is to add an assignment that would otherwise be redundant:
 ```js
 function addNumber() {
 	numbers.push(numbers.length + 1);
-	numbers = numbers;
+	+++numbers = numbers;+++
 }
 ```
 
@@ -17,7 +17,7 @@ But there's a more idiomatic solution:
 
 ```js
 function addNumber() {
-	numbers = [...numbers, numbers.length + 1];
+	numbers = +++[...numbers, numbers.length + 1];+++
 }
 ```
 

--- a/content/tutorial/01-svelte/03-props/01-declaring-props/README.md
+++ b/content/tutorial/01-svelte/03-props/01-declaring-props/README.md
@@ -8,7 +8,7 @@ In any real application, you'll need to pass data from one component down to its
 
 ```svelte
 <script>
-	export let answer;
+	+++export+++ let answer;
 </script>
 ```
 

--- a/content/tutorial/01-svelte/03-props/02-default-values/README.md
+++ b/content/tutorial/01-svelte/03-props/02-default-values/README.md
@@ -6,7 +6,7 @@ We can easily specify default values for props in `Nested.svelte`:
 
 ```svelte
 <script>
-	export let answer = 'a mystery';
+	export let answer +++= 'a mystery'+++;
 </script>
 ```
 
@@ -14,5 +14,5 @@ If we now add a second component _without_ an `answer` prop, it will fall back t
 
 ```svelte
 <Nested answer={42}/>
-<Nested/>
++++<Nested/>+++
 ```

--- a/content/tutorial/01-svelte/03-props/03-spread-props/README.md
+++ b/content/tutorial/01-svelte/03-props/03-spread-props/README.md
@@ -5,7 +5,7 @@ title: Spread props
 If you have an object of properties, you can 'spread' them onto a component instead of specifying each one:
 
 ```svelte
-<PackageInfo {...pkg}/>
+<PackageInfo +++{...pkg}+++/>
 ```
 
 > Conversely, if you need to reference all the props that were passed into a component, including ones that weren't declared with `export`, you can do so by accessing `$$props` directly. It's not generally recommended, as it's difficult for Svelte to optimise, but it's useful in rare cases.

--- a/content/tutorial/01-svelte/04-logic/01-if-blocks/README.md
+++ b/content/tutorial/01-svelte/04-logic/01-if-blocks/README.md
@@ -7,17 +7,17 @@ HTML doesn't have a way of expressing _logic_, like conditionals and loops. Svel
 To conditionally render some markup, we wrap it in an `if` block:
 
 ```svelte
-{#if user.loggedIn}
++++{#if user.loggedIn}+++
 	<button on:click={toggle}>
 		Log out
 	</button>
-{/if}
++++{/if}+++
 
-{#if !user.loggedIn}
++++{#if !user.loggedIn}+++
 	<button on:click={toggle}>
 		Log in
 	</button>
-{/if}
++++{/if}+++
 ```
 
 Try it — update the component, and click on the buttons.

--- a/content/tutorial/01-svelte/04-logic/01-if-blocks/app-a/src/lib/App.svelte
+++ b/content/tutorial/01-svelte/04-logic/01-if-blocks/app-a/src/lib/App.svelte
@@ -6,5 +6,10 @@
 	}
 </script>
 
-<button on:click={toggle}>Log out</button>
-<button on:click={toggle}>Log in</button>
+<button on:click={toggle}>
+	Log out
+</button>
+
+<button on:click={toggle}>
+	Log in
+</button>

--- a/content/tutorial/01-svelte/04-logic/01-if-blocks/app-b/src/lib/App.svelte
+++ b/content/tutorial/01-svelte/04-logic/01-if-blocks/app-b/src/lib/App.svelte
@@ -7,9 +7,13 @@
 </script>
 
 {#if user.loggedIn}
-	<button on:click={toggle}>Log out</button>
+	<button on:click={toggle}>
+		Log out
+	</button>
 {/if}
 
 {#if !user.loggedIn}
-	<button on:click={toggle}>Log in</button>
+	<button on:click={toggle}>
+		Log in
+	</button>
 {/if}

--- a/src/lib/server/markdown.js
+++ b/src/lib/server/markdown.js
@@ -29,6 +29,24 @@ function escape(html) {
 	return html.replace(/[&<>]/g, (c) => chars[c]);
 }
 
+const delimiter_substitutes = {
+	'+++': '             ',
+	'---': '           ',
+	'===': '         '
+};
+
+/**
+ * @param {string} content
+ * @param {string} classname
+ */
+function highlight_spans(content, classname) {
+	console.log(content);
+	return `<span class="${classname}">${content}</span>`;
+	// return content.replace(/<span class="([^"]+)"/g, (_, classnames) => {
+	// 	return `<span class="${classname} ${classnames}"`;
+	// });
+}
+
 marked.use({
 	renderer: {
 		code: (source, language, current) => {
@@ -51,6 +69,9 @@ marked.use({
 						tabs += '  ';
 					}
 					return prefix + tabs;
+				})
+				.replace(/([+=-]{3})/g, (_, delimiter) => {
+					return delimiter_substitutes[delimiter];
 				})
 				.replace(/\*\\\//g, '*/');
 
@@ -85,23 +106,16 @@ marked.use({
 				}<pre class='language-${plang}'><code>${highlighted}</code></pre></div>`;
 			}
 
-			return html.replace(
-				/^(\s+)<span class="token comment">([\s\S]+?)<\/span>\n/gm,
-				(match, intro_whitespace, content) => {
-					// we use some CSS trickery to make comments break onto multiple lines while preserving indentation
-					const lines = (intro_whitespace + content).split('\n');
-					return lines
-						.map((line) => {
-							const match = /^(\s*)(.*)/.exec(line);
-							const indent = (match[1] ?? '').replace(/\t/g, '  ').length;
-
-							return `<span class="token comment wrapped" style="--indent: ${indent}ch">${
-								line ?? ''
-							}</span>`;
-						})
-						.join('');
-				}
-			);
+			return html
+				.replace(/ {13}([^ ][^]+?) {13}/g, (_, content) => {
+					return highlight_spans(content, 'highlight add');
+				})
+				.replace(/ {11}([^ ][^]+?) {11}/g, (_, content) => {
+					return highlight_spans(content, 'highlight remove');
+				})
+				.replace(/ {9}([^ ][^]+?) {9}/g, (_, content) => {
+					return highlight_spans(content, 'highlight');
+				});
 		}
 	}
 });

--- a/src/routes/tutorial/[slug]/index.svelte
+++ b/src/routes/tutorial/[slug]/index.svelte
@@ -509,6 +509,21 @@
 		content: none;
 	}
 
+	.text :global(pre) :global(.highlight) {
+		--color: rgba(220, 220, 0, 0.2);
+		background: var(--color);
+		outline: 2px solid var(--color);
+		border-radius: 2px;
+	}
+
+	.text :global(pre) :global(.highlight.add) {
+		--color: rgba(0, 255, 0, 0.2);
+	}
+
+	.text :global(pre) :global(.highlight.remove) {
+		--color: rgba(255, 0, 0, 0.2);
+	}
+
 	.text :global(blockquote) {
 		background: var(--second);
 		margin: 2rem 0;


### PR DESCRIPTION
this adds inline highlights, which closes #28 by combining them — we use standalone code (since it was rightly pointed out that diffs might be confusing to newcomers) but highlight the bit of code we want to draw attention to:

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/1162160/172717146-57467ae3-78d5-418a-b0f8-f185b87c1b05.png">

there are three kinds of highlight annotations — `+++{added}+++`, `---{removed}---` and `==={highlighted}===`, which are green, red and yellow. so far i'm only using `+++`