### PR TITLE
prevent image viewer from taking over

### DIFF
--- a/src/routes/tutorial/[slug]/index.svelte
+++ b/src/routes/tutorial/[slug]/index.svelte
@@ -475,6 +475,7 @@
 	}
 
 	.editor-container {
+		position: relative;
 		background-color: var(--light-blue);
 	}
 </style>


### PR DESCRIPTION
adds a strategic `position: relative`. the image itself is failing to load. not sure why, but that's a separate issue