### PR TITLE
get non-webcontainer version working, and embeddable on cross-origin-isolated site

### DIFF
--- a/src/routes/tutorial/[slug]/_/Loading.svelte
+++ b/src/routes/tutorial/[slug]/_/Loading.svelte
@@ -5,7 +5,7 @@
 
 <div class="loading">
 	{#if initial}
-		<p>Initializing WebContainer. This may take a few seconds</p>
+		<p>initializing... this may take a few seconds</p>
 	{/if}
 
 	<svg width="107" height="128" viewBox="0 0 107 128">

--- a/src/routes/tutorial/[slug]/index.svelte
+++ b/src/routes/tutorial/[slug]/index.svelte
@@ -138,7 +138,10 @@
 		if (adapter) {
 			await adapter.reset(Object.values(b));
 		} else {
-			const module = await import('$lib/client/adapters/webcontainer/index.js');
+			const module = import.meta.env.VITE_USE_FILESYSTEM
+				? await import('$lib/client/adapters/filesystem/index.js')
+				: await import('$lib/client/adapters/webcontainer/index.js');
+
 			adapter = await module.create(Object.values(b));
 		}
 


### PR DESCRIPTION
This re-enables the non-WebContainer version of the app, which I need for demo purposes (it might also prove useful for people using Safari etc).

To do it in such a way that the site can be embedded on a page with cross-origin isolation, we need to inject a `src/hooks.js` file. For now it only adds one if it doesn't already exist; to be complete we'd need to do something like rename the existing `src/hooks.js` to `src/_hooks.js`, then do this:

```js
export * from './_hooks.js';
import { handle as original_handle } from './_hooks.js';

export async function handle({ event, resolve }) {
  const response = await original_handle({ event, resolve });
  response.headers.set('...');
  return response;
}
```

I'm too lazy to do that right now though.

To enable filesystem mode, start the server with `VITE_USE_FILESYSTEM=1 pnpm dev`.