### PR TITLE
Fix keyboard navigation issues on menu

### DIFF
--- a/src/routes/tutorial/[slug]/_/Menu/Menu.svelte
+++ b/src/routes/tutorial/[slug]/_/Menu/Menu.svelte
@@ -51,16 +51,16 @@
 	 * @param {HTMLElement} node
 	 */
 	function close_when_focus_leaves(node) {
-		function handleFocusIn() {
+		function handle_focus_in() {
 			if (!node.contains(document.activeElement)) {
 				is_open = false;
 			}
 		}
-		document.addEventListener('focusin', handleFocusIn)
+		document.addEventListener('focusin', handle_focus_in)
 
 		return {
 			destroy: () => {
-				document.removeEventListener('focusin', handleFocusIn);
+				document.removeEventListener('focusin', handle_focus_in);
 			}
 		}
 	}


### PR DESCRIPTION
Closes #85 and fixes some keyboard navigation issues I noticed.

- the heading and next/prev buttons were directly after the toggle in the DOM order. This meant that once the menu opened, they received focus first behind the menu. I moved them after the menu so we don't have that issue
- hide the menu using visibility: hidden so it doesn't receive focus when the menu is closed. I had to update the CSS transition to preserve the original slide in/out.
- automatically close the menu when focus leaves using an action. this makes it so that after tabbing past the end of the menu, the menu automatically closes and focus is on the "next" link. Otherwise, it wouldn't be clear where focus landed. I wrapped the toggle + the menu in a div to enable this, otherwise opening the menu, tabbing to the search, and tabbing back would close the menu. This method was inspired by [Andy Bell](https://piccalil.li/tutorial/build-a-fully-responsive-progressively-enhanced-burger-menu/#:~:text=The%20next%20part%20is%20an,force%20the%20menu%20closed%2C%20immediately.)
- apply focus styles to section toggles (#85)