### PR TITLE
Remove invalid statement in onMount tutorial

### DIFF
--- a/content/tutorial/01-svelte/07-lifecycle/01-onmount/README.md
+++ b/content/tutorial/01-svelte/07-lifecycle/01-onmount/README.md
@@ -4,7 +4,7 @@ title: onMount
 
 Every component has a _lifecycle_ that starts when it is created, and ends when it is destroyed. There are a handful of functions that allow you to run code at key moments during that lifecycle.
 
-The one you'll use most frequently is `onMount`, which runs after the component is first rendered to the DOM. We briefly encountered it [earlier](/tutorial/bind-this) when we needed to interact with a `<canvas>` element after it had been rendered.
+The one you'll use most frequently is `onMount`, which runs after the component is first rendered to the DOM.
 
 We'll add an `onMount` handler that loads some data over the network:
 


### PR DESCRIPTION
Removes an old reference in the onMount tutorial as the reference has been moved to the advanced section and is no longer before this part.

See: https://learn.svelte.dev/tutorial/onmount (Part 1 / Lifecycle / onMount)
Removed section points to https://learn.svelte.dev/tutorial/bind-this (Part 3 / Advanced bindings / This) as "before"