### PR TITLE
[fix] make webcontainer integration more robust

### DIFF
--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -29,7 +29,11 @@ export async function create(stubs) {
 			reject(new Error('Timed out'));
 		}, 15000);
 
+		console.log('loading webcontainer');
+
 		const WebContainer = await load();
+
+		console.log('booting webcontainer');
 
 		vm = await WebContainer.boot();
 
@@ -42,7 +46,11 @@ export async function create(stubs) {
 			fulfil(base);
 		});
 
+		console.log('loading files');
+
 		await vm.loadFiles(tree);
+
+		console.log('unpacking modules');
 
 		const unzip = await vm.run(
 			{
@@ -59,6 +67,8 @@ export async function create(stubs) {
 		if (code !== 0) {
 			reject(new Error('Failed to initialize WebContainer'));
 		}
+
+		console.log('starting dev server');
 
 		await vm.run({ command: 'chmod', args: ['a+x', 'node_modules/vite/bin/vite.js'] });
 

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -26,7 +26,7 @@ export async function create(stubs) {
 
 	const base = await new Promise(async (fulfil, reject) => {
 		setTimeout(() => {
-			reject(new Error('Timed out'));
+			reject(new Error('Timed out starting WebContainer'));
 		}, 15000);
 
 		console.log('loading webcontainer');

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -117,6 +117,9 @@ export async function create(stubs) {
 				}
 			}
 
+			// For some reason, server-ready is fired again on resetting the files here.
+			// We need to wait for it to finish before we can continue, else we might
+			// request files from Vite before it's ready, leading to a timeout.
 			const promise = new Promise((fulfil, reject) => {
 				const error_unsub = vm.on('error', (error) => {
 					error_unsub();

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -149,6 +149,13 @@
 				let called = false;
 
 				window.addEventListener('message', function handler(e) {
+					console.log(
+						'incoming message',
+						e.origin !== adapter?.base,
+						e.origin,
+						adapter?.base,
+						e.data
+					);
 					if (e.origin !== adapter?.base) return;
 					if (e.data.type === 'ping') {
 						window.removeEventListener('message', handler);

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -237,7 +237,6 @@
 	 * @return {Promise<Array<{ name: string, code: string }>>}
 	 */
 	async function fetch_from_vite(names) {
-		console.trace('fetching the following files:', names);
 		/** @type {Window} */ (iframe.contentWindow).postMessage({ type: 'fetch', names }, '*');
 
 		return new Promise((fulfil, reject) => {

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -174,7 +174,7 @@
 
 				setTimeout(() => {
 					if (!called) {
-						reject(new Error('Timed out'));
+						reject(new Error('Timed out (re)starting adapter'));
 					}
 				}, 10000);
 			});
@@ -248,7 +248,7 @@
 			});
 
 			setTimeout(() => {
-				reject(new Error('Timed out'));
+				reject(new Error('Timed out fetching files from Vite'));
 			}, 5000);
 		});
 	}

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -237,6 +237,7 @@
 	 * @return {Promise<Array<{ name: string, code: string }>>}
 	 */
 	async function fetch_from_vite(names) {
+		console.trace('fetching the following files:', names);
 		/** @type {Window} */ (iframe.contentWindow).postMessage({ type: 'fetch', names }, '*');
 
 		return new Promise((fulfil, reject) => {


### PR DESCRIPTION
- add the wait time with the "reset iframe" hack for each time we (re)set the adapter
- listen to server-ready event during reset, because for some reason it's fired then, too. This avoid a race condition where Vite could be requested too early, resulting in a timeout
