### PR TITLE
[fix] webcontainer tweaks

### DIFF
--- a/src/lib/client/adapters/filesystem/index.js
+++ b/src/lib/client/adapters/filesystem/index.js
@@ -37,7 +37,7 @@ export async function create(stubs) {
 
 			await new Promise((f) => setTimeout(f, 100)); // wait for chokidar
 
-			return false; // always reload page, not worth optimizing for local dev at this point
+			return true; // always reload page, not worth optimizing for local dev at this point
 		},
 
 		/** @param {import('$lib/types').FileStub[]} stubs */

--- a/src/lib/client/adapters/filesystem/index.js
+++ b/src/lib/client/adapters/filesystem/index.js
@@ -36,6 +36,8 @@ export async function create(stubs) {
 			});
 
 			await new Promise((f) => setTimeout(f, 100)); // wait for chokidar
+
+			return false; // always reload page, not worth optimizing for local dev at this point
 		},
 
 		/** @param {import('$lib/types').FileStub[]} stubs */

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -56,7 +56,7 @@ async function _create(stubs) {
 			clearTimeout(timeout);
 			timeout = setTimeout(() => {
 				reject(new Error('Timed out starting WebContainer'));
-			}, 10000);
+			}, 15000);
 		}
 
 		reset_timeout();

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -124,7 +124,9 @@ async function _create(stubs) {
 	 * @param {import('$lib/types').Stub[]} stubs
 	 */
 	async function reset(stubs) {
+		console.log('resetting');
 		await running;
+		console.log('running awaited');
 		/** @type {Function} */
 		let resolve = () => {};
 		running = new Promise((fulfil) => (resolve = fulfil));
@@ -144,12 +146,14 @@ async function _create(stubs) {
 		const promise = new Promise((fulfil, reject) => {
 			const error_unsub = vm.on('error', (error) => {
 				error_unsub();
+				console.log('EERROOORRRRRR', error);
 				resolve();
 				reject(new Error(error.message));
 			});
 
 			const ready_unsub = vm.on('server-ready', (port, base) => {
 				ready_unsub();
+				console.log('SERVER READYYYY');
 				console.log(`server ready on port ${port} at ${performance.now()}: ${base}`);
 				resolve();
 				fulfil(undefined);
@@ -179,12 +183,15 @@ async function _create(stubs) {
 				console.error(e);
 			}
 		}
+		console.log('old deteled');
 
 		await vm.loadFiles(convert_stubs_to_tree(stubs));
 
+		console.log('new loaded');
 		await promise;
 
 		await new Promise((f) => setTimeout(f, 200)); // wait for chokidar
+		console.log('finish');
 
 		resolve();
 	}

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -198,7 +198,7 @@ async function _create(stubs) {
 
 		resolve();
 
-		return !will_restart && !vite_error;
+		return will_restart || vite_error;
 	}
 
 	/**

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -183,22 +183,7 @@ async function _create(stubs) {
 			: Promise.resolve();
 
 		for (const file of old.keys()) {
-			// TODO this fails with a cryptic error
-			// index.svelte:155 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'rmSync')
-			// at Object.rm (webcontainer.e2e246a845f9e80283581d6b944116e399af6950.js:6:121171)
-			// at MessagePort._0x4ec3f4 (webcontainer.e2e246a845f9e80283581d6b944116e399af6950.js:6:110957)
-			// at MessagePort.nrWrapper (headless:5:29785)
-			// await vm.fs.rm(file);
-
-			// temporary workaround
-			try {
-				await vm.run({
-					command: 'node',
-					args: ['-e', `fs.rmSync('${file.slice(1)}')`]
-				});
-			} catch (e) {
-				console.error(e);
-			}
+			await vm.fs.rm(file, { force: true, recursive: true });
 		}
 
 		await vm.loadFiles(convert_stubs_to_tree(new_stubs));

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -124,9 +124,7 @@ async function _create(stubs) {
 	 * @param {import('$lib/types').Stub[]} stubs
 	 */
 	async function reset(stubs) {
-		console.log('resetting');
 		await running;
-		console.log('running awaited');
 		/** @type {Function} */
 		let resolve = () => {};
 		running = new Promise((fulfil) => (resolve = fulfil));
@@ -146,14 +144,12 @@ async function _create(stubs) {
 		const promise = new Promise((fulfil, reject) => {
 			const error_unsub = vm.on('error', (error) => {
 				error_unsub();
-				console.log('EERROOORRRRRR', error);
 				resolve();
 				reject(new Error(error.message));
 			});
 
 			const ready_unsub = vm.on('server-ready', (port, base) => {
 				ready_unsub();
-				console.log('SERVER READYYYY');
 				console.log(`server ready on port ${port} at ${performance.now()}: ${base}`);
 				resolve();
 				fulfil(undefined);
@@ -183,15 +179,12 @@ async function _create(stubs) {
 				console.error(e);
 			}
 		}
-		console.log('old deteled');
 
 		await vm.loadFiles(convert_stubs_to_tree(stubs));
 
-		console.log('new loaded');
 		await promise;
 
 		await new Promise((f) => setTimeout(f, 200)); // wait for chokidar
-		console.log('finish');
 
 		resolve();
 	}

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -20,7 +20,8 @@ export type Stub = FileStub | DirectoryStub;
 
 export interface Adapter {
 	base: string;
-	reset(files: Array<Stub>): Promise<void>;
+	/** Returns `true` if the reset was in such a way that a reload of the iframe isn't needed */
+	reset(files: Array<Stub>): Promise<boolean>;
 	update(file: Array<FileStub>): Promise<void>;
 	destroy(): Promise<void>;
 }

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -20,7 +20,7 @@ export type Stub = FileStub | DirectoryStub;
 
 export interface Adapter {
 	base: string;
-	/** Returns `true` if the reset was in such a way that a reload of the iframe isn't needed */
+	/** Returns `false` if the reset was in such a way that a reload of the iframe isn't needed */
 	reset(files: Array<Stub>): Promise<boolean>;
 	update(file: Array<FileStub>): Promise<void>;
 	destroy(): Promise<void>;

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -143,16 +143,14 @@
 	async function reset_adapter(stubs) {
 		if (adapter) {
 			await adapter.reset(stubs);
-			return adapter;
 		} else {
 			const module = PUBLIC_USE_FILESYSTEM
 				? await import('$lib/client/adapters/filesystem/index.js')
 				: await import('$lib/client/adapters/webcontainer/index.js');
 
 			adapter = await module.create(stubs);
+			set_iframe_src(adapter.base);
 		}
-
-		set_iframe_src(adapter.base);
 
 		await new Promise((fulfil, reject) => {
 			let called = false;
@@ -185,7 +183,6 @@
 		await new Promise((fulfil) => setTimeout(fulfil, 200));
 		set_iframe_src(adapter.base);
 
-		console.log('did (re)set adapter');
 		return adapter;
 	}
 

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -222,7 +222,6 @@
 	async function load_files(stubs) {
 		adapter = await reset_adapter(stubs);
 		update_complete_states(stubs);
-		set_iframe_src(adapter.base);
 	}
 
 	/**

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -181,9 +181,16 @@
 			}, 10000);
 		});
 
+		console.log('before');
 		// necessary for some reason, else the iframe is out of date
 		await new Promise((fulfil) => setTimeout(fulfil, 200));
 		set_iframe_src(adapter.base);
+		console.log('after');
+
+		// necessary for some reason, else the iframe is out of date
+		await new Promise((fulfil) => setTimeout(fulfil, 2000));
+		set_iframe_src(adapter.base);
+		console.log('way after');
 
 		return adapter;
 	}

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -141,8 +141,9 @@
 	 * @param {import('$lib/types').Stub[]} stubs
 	 */
 	async function reset_adapter(stubs) {
+		let reload_iframe = true;
 		if (adapter) {
-			await adapter.reset(stubs);
+			reload_iframe = await adapter.reset(stubs);
 		} else {
 			const module = PUBLIC_USE_FILESYSTEM
 				? await import('$lib/client/adapters/filesystem/index.js')
@@ -179,9 +180,10 @@
 			}, 10000);
 		});
 
-		// necessary for some reason, else the iframe is out of date
-		await new Promise((fulfil) => setTimeout(fulfil, 200));
-		set_iframe_src(adapter.base);
+		if (reload_iframe) {
+			await new Promise((fulfil) => setTimeout(fulfil, 200));
+			set_iframe_src(adapter.base);
+		}
 
 		return adapter;
 	}

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -181,6 +181,10 @@
 			}, 10000);
 		});
 
+		// necessary for some reason, else the iframe is out of date
+		await new Promise((fulfil) => setTimeout(fulfil, 200));
+		set_iframe_src(adapter.base);
+
 		return adapter;
 	}
 

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -181,17 +181,11 @@
 			}, 10000);
 		});
 
-		console.log('before');
 		// necessary for some reason, else the iframe is out of date
 		await new Promise((fulfil) => setTimeout(fulfil, 200));
 		set_iframe_src(adapter.base);
-		console.log('after');
 
-		// necessary for some reason, else the iframe is out of date
-		await new Promise((fulfil) => setTimeout(fulfil, 2000));
-		set_iframe_src(adapter.base);
-		console.log('way after');
-
+		console.log('did (re)set adapter');
 		return adapter;
 	}
 

--- a/src/routes/tutorial/[slug]/Loading.svelte
+++ b/src/routes/tutorial/[slug]/Loading.svelte
@@ -43,7 +43,15 @@
 <div class="loading" class:error>
 	{#if error}
 		{@html get_error_message(error)}
-		<button on:click={() => dispatch('reload')}>Reload</button>
+		<button
+			on:click={() => {
+				if (initial) {
+					location.reload();
+				} else {
+					dispatch('reload');
+				}
+			}}>Reload</button
+		>
 	{:else}
 		{#if initial}
 			<p>initializing... this may take a few seconds</p>


### PR DESCRIPTION
- remove steps logic, turns out starting up is very robust if it goes well
- do a full page reload if something fails during initial boot
- make webcontainer a real singleton internally
- use the built-in `rm` method now (works now)
- don't reload iframe if not needed (better DX when solving/resetting)