### PR TITLE
Dynamic Attributes example: make example HTML consistent

### DIFF
--- a/content/tutorial/01-svelte/01-introduction/03-dynamic-attributes/README.md
+++ b/content/tutorial/01-svelte/01-introduction/03-dynamic-attributes/README.md
@@ -19,7 +19,7 @@ When building web apps, it's important to make sure that they're _accessible_ to
 In this case, we're missing the `alt` attribute that describes the image for people using screenreaders, or people with slow or flaky internet connections that can't download the image. Let's add one:
 
 ```svelte
-<img src={src} +++alt="A man dances."+++>
+<img src={src} +++alt="A man dances."+++ />
 ```
 
 We can use curly braces _inside_ attributes. Try changing it to `"{name} dances."` — remember to declare a `name` variable in the `<script>` block.
@@ -29,5 +29,5 @@ We can use curly braces _inside_ attributes. Try changing it to `"{name} dances.
 It's not uncommon to have an attribute where the name and value are the same, like `src={src}`. Svelte gives us a convenient shorthand for these cases:
 
 ```svelte
-<img +++{src}+++ alt="A man dances.">
+<img +++{src}+++ alt="A man dances." />
 ```


### PR DESCRIPTION
Updated the example to add consistency between the README and the editor experience.