### PR TITLE
fix relative link to discord

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -32,7 +32,7 @@
 	<svelte:fragment slot="nav-right">
 		<NavItem external="https://kit.svelte.dev">SvelteKit</NavItem>
 
-		<NavItem external="/chat" title="Discord Chat">
+		<NavItem external="https://svelte.dev/chat" title="Discord Chat">
 			<span class="small">Discord</span>
 			<span class="large"><Icon name="message-square" /></span>
 		</NavItem>


### PR DESCRIPTION
This fixes the previously relative link to the discord which didnt work.

Reproduce:
Go to [https://learn.svelte.dev/tutorial/introducing-sveltekit](https://learn.svelte.dev/tutorial/introducing-sveltekit) and click on the discord chat icon in the top right corner.
The link doesnt work.

The browser resolved it to https://learn.svelte.dev/chat which doesnt exist.
I changed it to the absolute link "https://svelte.dev/chat" to make the link work again.