### PR TITLE
fix: <a> tag in footer to open in a new tab

### DIFF
--- a/src/routes/tutorial/[slug]/Sidebar.svelte
+++ b/src/routes/tutorial/[slug]/Sidebar.svelte
@@ -73,7 +73,12 @@
 </div>
 
 <footer>
-	<a class="edit" href="https://github.com/sveltejs/learn.svelte.dev/tree/main/{exercise.dir}">
+	<a
+		target="_blank"
+		rel="noreferrer"
+		class="edit"
+		href="https://github.com/sveltejs/learn.svelte.dev/tree/main/{exercise.dir}"
+	>
 		Edit this page
 	</a>
 </footer>


### PR DESCRIPTION
If the content of the sidebar is long enough the users might misclick and choose the *Edit this page* link instead of the *Next: Lesson* link. By doing so, the link will open within the user lesson tab and even if they go back to their previous tab the code progress on that lesson will be lost.

This patch makes the <a> tag on the footer open in a new tab, so if the user misclicks on the link they can close it and continue normally.