### PR TITLE
Removed unused variable in tutorial/adding-parameters-to-actions

### DIFF
--- a/content/tutorial/03-advanced-svelte/04-actions/02-adding-parameters-to-actions/app-a/src/lib/longpress.js
+++ b/content/tutorial/03-advanced-svelte/04-actions/02-adding-parameters-to-actions/app-a/src/lib/longpress.js
@@ -1,4 +1,4 @@
-export function longpress(node, duration) {
+export function longpress(node) {
 	let timer;
 
 	const handleMousedown = () => {


### PR DESCRIPTION
Removed unused variable in tutorial/adding-parameters-to-actions 's first view. It should be placed after solving the problem