### PR TITLE
regain focus when it gets lost by mistake

### DIFF
--- a/src/routes/tutorial/[slug]/Editor.svelte
+++ b/src/routes/tutorial/[slug]/Editor.svelte
@@ -252,7 +252,7 @@
 
 				setTimeout(() => {
 					preserve_focus = true;
-				});
+				}, 0);
 			}
 		}}
 		on:focusin={() => {

--- a/src/routes/tutorial/[slug]/Editor.svelte
+++ b/src/routes/tutorial/[slug]/Editor.svelte
@@ -1,6 +1,5 @@
 <script>
 	import { dev } from '$app/environment';
-	import { monaco } from '$lib/client/monaco/monaco.js';
 	import { createEventDispatcher, onMount } from 'svelte';
 
 	/**
@@ -35,6 +34,8 @@
 
 	let w = 0;
 	let h = 0;
+
+	let preserve_focus = true;
 
 	onMount(() => {
 		let destroyed = false;
@@ -234,8 +235,37 @@
 	}
 </script>
 
+<svelte:window
+	on:pointerdown={(e) => {
+		if (!container.contains(/** @type {HTMLElement} */ (e.target))) {
+			preserve_focus = false;
+		}
+	}}
+/>
+
 <div bind:clientWidth={w} bind:clientHeight={h}>
-	<div bind:this={container} />
+	<div
+		bind:this={container}
+		on:keydown={(e) => {
+			if (e.key === 'Tab') {
+				preserve_focus = false;
+
+				setTimeout(() => {
+					preserve_focus = true;
+				});
+			}
+		}}
+		on:focusin={() => {
+			preserve_focus = true;
+		}}
+		on:focusout={() => {
+			if (preserve_focus) {
+				setTimeout(() => {
+					instance?.editor.focus();
+				}, 0);
+			}
+		}}
+	/>
 </div>
 
 <style>

--- a/src/routes/tutorial/[slug]/Editor.svelte
+++ b/src/routes/tutorial/[slug]/Editor.svelte
@@ -35,6 +35,11 @@
 	let w = 0;
 	let h = 0;
 
+	/** 
+	 * The iframe sometimes takes focus control in ways we can't prevent
+	 * while the editor is focussed. Refocus the editor in these cases.
+	 * This boolean tracks whether or not the editor should be refocused.
+	 */
 	let preserve_focus = true;
 
 	onMount(() => {


### PR DESCRIPTION
closes #150.

There are basically three ways that the editor could lose focus:

1. the user clicked on the page outside the editor
2. the user tabbed after hitting the `Ctrl-M` or `Ctrl-Shift-M` (on Mac) combo (which temporarily disables focus trapping, I learned today)
3. the iframe captures it

All we need to do, therefore, is determine whether a `focusout` event was caused by 1 or 2, and if so, recapture the focus. It seems to work reliably for me