### PR TITLE
Remove unnecessary and inconsistent quotation marks

### DIFF
--- a/content/tutorial/01-svelte/08-stores/06-store-bindings/README.md
+++ b/content/tutorial/01-svelte/08-stores/06-store-bindings/README.md
@@ -15,7 +15,7 @@ Changing the input value will now update `name` and all its dependents.
 We can also assign directly to store values inside a component. Add a `<button>` element:
 
 ```svelte
-<button on:click="{() => $name += '!'}">
+<button on:click={() => $name += '!'}>
 	Add exclamation mark!
 </button>
 ```


### PR DESCRIPTION
# Reasons
- Quotation marks not necessary for code to compile
- The solution code does not use those quotation marks
- Creating strings inside of the quotation marks is uncomfortable