### PR TITLE
fix: Added missing import 

### DIFF
--- a/content/tutorial/02-sveltekit/04-forms/03-form-validation/README.md
+++ b/content/tutorial/02-sveltekit/04-forms/03-form-validation/README.md
@@ -56,6 +56,7 @@ It would be much better to stay on the same page and provide an indication of wh
 ```js
 /// file: src/routes/+page.server.js
 +++import { fail } from '@sveltejs/kit';+++
+import * as db from '$lib/server/database.js';
 
 export function load({ cookies }) {...}
 


### PR DESCRIPTION
In _Part 2: Introduction to SvelteKit / Forms / Validation_, the code instruction in the left panel lacks a code line.

It's a minor mistake, but it might confuse beginners.

![screenshot](https://user-images.githubusercontent.com/1882216/210066713-116184d3-dc60-48a5-a000-b7132ba48da9.png)
