### PR TITLE
[fix] load images in Part 1 / Lifecycle / onMount excercise

### DIFF
--- a/content/tutorial/01-svelte/07-lifecycle/01-onmount/README.md
+++ b/content/tutorial/01-svelte/07-lifecycle/01-onmount/README.md
@@ -2,8 +2,6 @@
 title: onMount
 ---
 
-> The images in this exercise don't currently work. You can switch to the old tutorial instead: https://svelte.dev/tutorial/onmount
-
 Every component has a _lifecycle_ that starts when it is created, and ends when it is destroyed. There are a handful of functions that allow you to run code at key moments during that lifecycle.
 
 The one you'll use most frequently is `onMount`, which runs after the component is first rendered to the DOM.

--- a/content/tutorial/01-svelte/07-lifecycle/01-onmount/app-a/src/lib/App.svelte
+++ b/content/tutorial/01-svelte/07-lifecycle/01-onmount/app-a/src/lib/App.svelte
@@ -8,6 +8,7 @@
 	{#each photos as photo}
 		<figure>
 			<img
+				crossorigin="anonymous"
 				src={photo.thumbnailUrl}
 				alt={photo.title}
 			/>

--- a/content/tutorial/01-svelte/07-lifecycle/01-onmount/app-b/src/lib/App.svelte
+++ b/content/tutorial/01-svelte/07-lifecycle/01-onmount/app-b/src/lib/App.svelte
@@ -17,6 +17,7 @@
 	{#each photos as photo}
 		<figure>
 			<img
+				crossorigin="anonymous"
 				src={photo.thumbnailUrl}
 				alt={photo.title}
 			/>


### PR DESCRIPTION
This PR is about to fix the images for the _Part 1 / Lifecycle / onMount_ excercise

While doing the tutorial, I noticed the images were not loading due to an error of type:
```
GET https://via.placeholder.com/150/61d552 net::ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep 200
```

By adding:

```
crossorigin="anonymous"
```
To the images, they appear as expected.

I've added the attribute to the initial and the solved state, and removed the warning from the Readme.

Without the attribute:
![image](https://user-images.githubusercontent.com/6088653/210086923-9b60ec3b-a947-4e3f-ab3c-37908b078f9e.png)


With the attribute:
![image](https://user-images.githubusercontent.com/6088653/210086964-02f7e660-3e87-4811-827d-0da040185f52.png)
