### PR TITLE
[fix] dice calculation in "GET handlers"

### DIFF
--- a/content/tutorial/02-sveltekit/05-api-routes/01-get-handlers/README.md
+++ b/content/tutorial/02-sveltekit/05-api-routes/01-get-handlers/README.md
@@ -9,7 +9,7 @@ This app fetches data from a `/roll` API route when you click the button. Create
 ```js
 /// file: src/routes/roll/+server.js
 export function GET() {
-	const number = Math.ceil(Math.random() * 6);
+	const number = Math.floor(Math.random() * 6) + 1;
 
 	return new Response(number, {
 		headers: {
@@ -28,7 +28,7 @@ Request handlers must return a [Response](https://developer.mozilla.org/en-US/do
 +++import { json } from '@sveltejs/kit';+++
 
 export function GET() {
-	const number = Math.ceil(Math.random() * 6);
+	const number = Math.floor(Math.random() * 6) + 1;
 
 ---	return new Response(number, {
 		headers: {

--- a/content/tutorial/02-sveltekit/05-api-routes/01-get-handlers/app-b/src/routes/roll/+server.js
+++ b/content/tutorial/02-sveltekit/05-api-routes/01-get-handlers/app-b/src/routes/roll/+server.js
@@ -1,7 +1,7 @@
 import { json } from '@sveltejs/kit';
 
 export function GET() {
-	const number = Math.ceil(Math.random() * 6);
+	const number = Math.floor(Math.random() * 6) + 1;
 
 	return json(number);
 }


### PR DESCRIPTION
The tutorial on GET handlers includes a simulation of a dice roll:
`const number = Math.ceil(Math.random() * 6);`

While unlikely, the result of that dice roll might actually be 0. This is because Math.random() returns a number greater than or _equal to 0_.

This PR fixes that by using the follwoing code for the dice roll:
`const number = Math.floor(Math.random() * 6) + 1;`

----
Otherwise thanks for the great tutorial and congrats on the release of SvelteKit!