### PR TITLE
[fix] highlight 04-forms / 02-named-form-actions

### DIFF
--- a/content/tutorial/02-sveltekit/04-forms/02-named-form-actions/README.md
+++ b/content/tutorial/02-sveltekit/04-forms/02-named-form-actions/README.md
@@ -12,7 +12,7 @@ export const actions = {
 	+++create+++: async ({ cookies, request }) => {
 		const data = await request.formData();
 		db.createTodo(cookies.get('userid'), data.get('description'));
-	},
+	}+++,+++
 
 +++	delete: async ({ cookies, request }) => {
 		const data = await request.formData();


### PR DESCRIPTION
Highlighting the comma in the Task's readme to avoid simple error when copy-pasting.