### PR TITLE
add comma

### DIFF
--- a/content/tutorial/03-advanced-svelte/04-actions/02-adding-parameters-to-actions/README.md
+++ b/content/tutorial/03-advanced-svelte/04-actions/02-adding-parameters-to-actions/README.md
@@ -36,7 +36,7 @@ To change that, we can add an `update` method in `longpress.js`. This will be ca
 return {
 	update(newDuration) {
 		duration = newDuration;
-	}
+	},
 	// ...
 };
 ```


### PR DESCRIPTION
The tutorial shows adding a new update method to the object being returned, but without the comma showing up there. This results in a syntax error if copied exactly, and it confused me for a minute.