### PR TITLE
fix: better iframe navigation

### DIFF
--- a/src/routes/tutorial/[slug]/Output.svelte
+++ b/src/routes/tutorial/[slug]/Output.svelte
@@ -213,7 +213,7 @@
 		if (new_path) {
 			ignore_path_change = true;
 			[history_bwd, history_fwd] = [history_bwd.slice(0, -1), [path, ...history_fwd]];
-			route_to(new_path);
+			iframe.contentWindow?.postMessage({ type: 'goto', path: new_path }, '*');
 		}
 	}
 
@@ -222,7 +222,7 @@
 		if (new_path) {
 			ignore_path_change = true;
 			[history_bwd, history_fwd] = [[...history_bwd, path], history_fwd.slice(1)];
-			route_to(new_path);
+			iframe.contentWindow?.postMessage({ type: 'goto', path: new_path }, '*');
 		}
 	}
 </script>


### PR DESCRIPTION
alternative to #187 which keeps the back/fwd navigation while also fixing the weird history pollution from iframe to parent (which was there regardless of the back/fwd navigation feature)

- uses postMessage to trigger the inner SvelteKit's goto method
- monkeypatches iframe's history.pushState to use replaceState instead to not create history entries, keeping the parent window's navigation order intact