### PR TITLE
Implement backward and forward navigation options to iframed window (2)

### DIFF
--- a/src/routes/tutorial/[slug]/Output.svelte
+++ b/src/routes/tutorial/[slug]/Output.svelte
@@ -57,11 +57,7 @@
 			}
 		});
 
-		function on_iframe_load() {
-			iframe.classList.add('loaded');
-		}
 		function destroy() {
-			iframe.removeEventListener('load', on_iframe_load);
 			unsub();
 			if (adapter) {
 				adapter.destroy();
@@ -69,7 +65,6 @@
 		}
 
 		document.addEventListener('pagehide', destroy);
-		iframe.addEventListener('load', on_iframe_load);
 		return destroy;
 	});
 
@@ -99,7 +94,7 @@
 			adapter = _adapter;
 			await _adapter.init;
 
-			set_iframe_src(adapter.base + path);
+			iframe.src = adapter.base + path;
 		}
 
 		await new Promise((fulfil, reject) => {
@@ -118,7 +113,7 @@
 				if (!called) {
 					// Updating the iframe too soon sometimes results in a blank screen,
 					// so we try again after a short delay if we haven't heard back
-					set_iframe_src(adapter.base + path);
+					iframe.src = adapter.base + path;
 				}
 			}, 5000);
 
@@ -131,7 +126,7 @@
 
 		if (reload_iframe) {
 			await new Promise((fulfil) => setTimeout(fulfil, 200));
-			set_iframe_src(adapter.base + path);
+			iframe.src = adapter.base + path;
 		}
 
 		return adapter;
@@ -142,7 +137,7 @@
 	function schedule_iframe_reload() {
 		clearTimeout(reload_timeout);
 		reload_timeout = setTimeout(() => {
-			set_iframe_src(adapter.base + path);
+			iframe.src = adapter.base + path;
 		}, 1000);
 	}
 
@@ -172,7 +167,7 @@
 
 				// we lost contact, refresh the page
 				loading = true;
-				set_iframe_src(adapter.base + path);
+				iframe.src = adapter.base + path;
 				loading = false;
 			}, 1000);
 		} else if (e.data.type === 'ping-pause') {
@@ -180,23 +175,11 @@
 		}
 	}
 
-	/** @param {string} src */
-	function set_iframe_src(src) {
-		// removing the iframe from the document allows us to
-		// change the src without adding a history entry, which
-		// would make back/forward traversal very annoying
-		const parentNode = /** @type {HTMLElement} */ (iframe.parentNode);
-		iframe.classList.remove('loaded');
-		parentNode?.removeChild(iframe);
-		iframe.src = src;
-		parentNode?.appendChild(iframe);
-	}
-
 	/** @param {string} path */
 	function route_to(path) {
 		const url = new URL(path, adapter.base);
 		path = url.pathname + url.search + url.hash;
-		set_iframe_src(adapter.base + path);
+		iframe.src = adapter.base + path;
 	}
 
 	/** @param {string | null} new_path */
@@ -234,7 +217,7 @@
 	{path}
 	{loading}
 	on:refresh={() => {
-		set_iframe_src(adapter.base + path);
+		iframe.src = adapter.base + path;
 	}}
 	on:change={(e) => nav_to(e.detail.value)}
 	on:back={go_bwd}
@@ -271,9 +254,5 @@
 		box-sizing: border-box;
 		border: none;
 		background: var(--sk-back-2);
-	}
-
-	iframe:not(.loaded) {
-		display: none;
 	}
 </style>


### PR DESCRIPTION
**Note:** This PR builds on the merged (and possibly soon-to-be-reverted [PR #181](https://github.com/sveltejs/learn.svelte.dev/pull/181)) and removes the `set_iframe_scr` function and `loaded` architecture so that the app navigates backward and forward seamlessly.

---

## Overview of changes

This PR adds backward and forward navigation options to iframed window. Because this sort of behavior isn't normally possible within the natural constraints of the History API since the history of the iframed window and that of its containing parent window operate together, I opted to manually track the history of the iframed window in two arrays— `history_bwd` and `history_fwd`.

#### Implementation/test cases & detailed steps for each

<details><summary>When any path is manually entered into the iframe's simulated address field… <em>(expand to see details)</em></summary><ul>
<li>the current <code>path</code> is appended to <code>history_bwd</code></li>
<li><code>history_fwd</code> is reset</li>
<li>the new <code>path</code> is naturally set to the entered path (current functionality)</li></ul></details>

<details><summary>When the "back" button is clicked… <em>(expand to see details)</em></summary><ul>
<li>the current <code>path</code> is prepended to <code>history_fwd</code></li>
<li>the last item in <code>history_bwd</code> is sliced off</li>
<li>the sliced item (the previous <code>path</code>) replaces the current <code>path</code></li></ul></details>

<details><summary>When the "forward" button is clicked… <em>(expand to see details)</em></summary><ul>
<li>the current <code>path</code> is appended to <code>history_bwd</code></li>
<li>the first item in <code>history_fwd</code> is sliced off</li>
<li>the sliced item (the next <code>path</code>) replaces the current <code>path</code></li></ul></details>

<details><summary>When any link within the iframe is clicked, it is picked up by <code>handle_message</code> which then falls back to using the <code>nav_to</code> function for handling and tracking the history accordingly, effectively… <em>(expand to see details)</em></summary><ul>
<li>the current <code>path</code> is appended to <code>history_bwd</code></li>
<li><code>history_fwd</code> is reset</li>
<li>the new <code>path</code> is naturally set to the entered path (current functionality)</li></ul></details>

## Notes

* The icons I used are custom ones I threw together in Illustrator, so feel free to use them without any risk of copyright violations, though I understand there are probably plenty of reasons to switch them, even just to stay on brand.
* I noticed after my initial successful tests that while the back/forward functionality worked as expected, the history persisted across tutorials, so I added an additional `reset_history` function that resets the history, which I trigger in the `try` clause within `afterNavigate`.

## Testing

This can be tested/demoed effectively using any of the routing examples:
* [Pages](https://learn-svelte-dfhs4unjp-svelte.vercel.app/tutorial/pages)
* [Layouts](https://learn-svelte-dfhs4unjp-svelte.vercel.app/tutorial/layouts)
* [Routing parameters](https://learn-svelte-dfhs4unjp-svelte.vercel.app/tutorial/params)

## Screen recording

https://user-images.githubusercontent.com/5913254/214125029-882cce97-ab8f-46f6-996e-b5743fb5a287.mov