### PR TITLE
fix: typed characters to be entered correctly

### DIFF
--- a/content/tutorial/common/src/__client.js
+++ b/content/tutorial/common/src/__client.js
@@ -68,6 +68,18 @@ window.addEventListener('message', async (e) => {
  * while the editor is focussed. Refocus the editor in these cases.
  */
 window.addEventListener('focusin', (e) => {
+	/**
+	 * This condition would only be `true` if the iframe took focus when loaded,
+	 * and `false` in other cases, for example:
+	 * - navigation inside the iframe - for example, if you click a link inside
+	 *   the iframe, the `focusin` event will be fired twice, the first time
+	 *   `e.target` will be its anchor, the second time `e.target` will be body,
+	 *   and `e.relatedTarget` will be its anchor (if `csr = false` in only the
+	 *   first `focusin` event will be fired)
+	 * - an element such as input gets focus (either from inside or outside the
+	 *   iframe) - for example, if an input inside the iframe gets focus,
+	 *   `e.target` will be the input.
+	 */
 	if (
 		e.target.tagName === 'BODY' &&
 		!e.target.contains(e.relatedTarget)

--- a/content/tutorial/common/src/__client.js
+++ b/content/tutorial/common/src/__client.js
@@ -63,13 +63,22 @@ window.addEventListener('message', async (e) => {
 	}
 });
 
-window.addEventListener('pointerdown', () => {
-	parent.postMessage(
-		{
-			type: 'pointerdown'
-		},
-		'*'
-	);
+/**
+ * The iframe sometimes takes focus control in ways we can't prevent
+ * while the editor is focussed. Refocus the editor in these cases.
+ */
+window.addEventListener('focusin', (e) => {
+	if (
+		e.target.tagName === 'BODY' &&
+		!e.target.contains(e.relatedTarget)
+	) {
+		parent.postMessage(
+			{
+				type: 'iframe_took_focus'
+			},
+			'*'
+		);
+	}
 });
 
 function ping() {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
 		"dev": "vite dev",
 		"build": "node scripts/create-common-bundle && vite build && node scripts/create-middleware",
 		"preview": "vite preview",
+		"test": "playwright test",
 		"check": "svelte-check --tsconfig ./jsconfig.json",
 		"check:watch": "svelte-check --tsconfig ./jsconfig.json --watch",
 		"lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. .",
 		"format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. ."
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.30.0",
 		"@sveltejs/adapter-auto": "1.0.0-next.90",
 		"@sveltejs/adapter-vercel": "1.0.0-next.85",
 		"@sveltejs/kit": "next",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,10 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+	webServer: {
+		command: 'pnpm build && pnpm preview',
+		port: 4173
+	}
+};
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@fontsource/roboto-mono': ^4.5.7
+  '@playwright/test': ^1.30.0
   '@sveltejs/adapter-auto': 1.0.0-next.90
   '@sveltejs/adapter-vercel': 1.0.0-next.85
   '@sveltejs/kit': next
@@ -42,9 +43,10 @@ dependencies:
   ws: 8.11.0
 
 devDependencies:
+  '@playwright/test': 1.30.0
   '@sveltejs/adapter-auto': 1.0.0-next.90
   '@sveltejs/adapter-vercel': 1.0.0-next.85
-  '@sveltejs/kit': 1.0.0-next.586_svelte@3.54.0+vite@4.0.0
+  '@sveltejs/kit': 1.0.0-next.589_svelte@3.54.0+vite@4.0.0
   '@sveltejs/site-kit': 3.0.3
   '@types/diff': 5.0.2
   '@types/marked': 4.0.8
@@ -328,6 +330,15 @@ packages:
       fastq: 1.14.0
     dev: true
 
+  /@playwright/test/1.30.0:
+    resolution: {integrity: sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      '@types/node': 18.11.13
+      playwright-core: 1.30.0
+    dev: true
+
   /@polka/url/1.0.0-next.21:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
@@ -356,8 +367,8 @@ packages:
       - supports-color
     dev: true
 
-  /@sveltejs/kit/1.0.0-next.586_svelte@3.54.0+vite@4.0.0:
-    resolution: {integrity: sha512-lTYWy4voh/r4jz8qnurIATyrH2ZgHPUswYQ9KauyASSjQGYeB1TPDgwcafM/LtgMxpcvFgWsx2KeflykSHXKxg==}
+  /@sveltejs/kit/1.0.0-next.589_svelte@3.54.0+vite@4.0.0:
+    resolution: {integrity: sha512-5ABRw46z9B+cCe/YWhcx+I/azNZg1NCDEkVJifZn8ToFoJ3a1eP0OexNIrvMEWpllMbNMPcJm2TC9tnz9oPfWQ==}
     engines: {node: '>=16.14'}
     hasBin: true
     requiresBuild: true
@@ -1282,6 +1293,12 @@ packages:
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+    dev: true
+
+  /playwright-core/1.30.0:
+    resolution: {integrity: sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==}
+    engines: {node: '>=14'}
+    hasBin: true
     dev: true
 
   /port-authority/2.0.1:

--- a/tests/focus_management.spec.ts
+++ b/tests/focus_management.spec.ts
@@ -8,12 +8,13 @@ const iframe_selector = 'iframe[src*="webcontainer.io/"]';
 
 test('focus management: the editor keeps focus when iframe is loaded', async () => {
 	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
-	const page = await context.newPage();
+	const page = context.pages()[0];
+	await page.bringToFront();
 
 	await page.goto('/tutorial/your-first-component');
 
 	// first, focus the editor before the iframe is loaded
-	await page.locator(editor_selector).click({ delay: 500 });
+	await page.locator(editor_selector).click({ delay: 1000 });
 
 	// at this time, expect focus to be on the editor
 	await expect(page.locator(editor_focus_selector)).toBeFocused();
@@ -32,7 +33,8 @@ test('focus management: the editor keeps focus when iframe is loaded', async () 
 
 test('focus management: input inside the iframe gets focus when clicking it', async () => {
 	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
-	const page = await context.newPage();
+	const page = context.pages()[0];
+	await page.bringToFront();
 
 	await page.goto('/tutorial/named-form-actions');
 
@@ -42,7 +44,7 @@ test('focus management: input inside the iframe gets focus when clicking it', as
 	await iframe.getByText('todos').waitFor();
 
 	// first, focus the editor
-	await page.locator(editor_selector).click({ delay: 500 });
+	await page.locator(editor_selector).click({ delay: 1000 });
 	await expect(page.locator(editor_focus_selector)).toBeFocused();
 
 	// then, click a input in the iframe
@@ -61,7 +63,8 @@ test('focus management: input inside the iframe gets focus when clicking it', as
 
 test('focus management: body inside the iframe gets focus when clicking a link inside the iframe', async () => {
 	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
-	const page = await context.newPage();
+	const page = context.pages()[0];
+	await page.bringToFront();
 
 	await page.goto('/tutorial/layouts');
 
@@ -71,7 +74,7 @@ test('focus management: body inside the iframe gets focus when clicking a link i
 	await iframe.getByText('this is the home page.').waitFor();
 
 	// first, focus the editor
-	await page.locator(editor_selector).click({ delay: 500 });
+	await page.locator(editor_selector).click({ delay: 1000 });
 	await expect(page.locator(editor_focus_selector)).toBeFocused();
 
 	// then, click a link in the iframe
@@ -91,7 +94,8 @@ test('focus management: body inside the iframe gets focus when clicking a link i
 
 test('focus management: the editor keeps focus while typing', async () => {
 	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
-	const page = await context.newPage();
+	const page = context.pages()[0];
+	await page.bringToFront();
 
 	await page.goto('/tutorial/your-first-component');
 

--- a/tests/focus_management.spec.ts
+++ b/tests/focus_management.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test, chromium } from '@playwright/test';
+
+const chromium_flags = ['--enable-features=SharedArrayBuffer'];
+
+const editor_selector = 'div.monaco-scrollable-element.editor-scrollable';
+const editor_focus_selector = 'textarea.inputarea.monaco-mouse-cursor-text';
+const iframe_selector = 'iframe[src*="webcontainer.io/"]';
+
+test('focus management: the editor keeps focus when iframe is loaded', async () => {
+	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
+	const page = await context.newPage();
+
+	await page.goto('/tutorial/your-first-component');
+
+	// first, focus the editor before the iframe is loaded
+	await page.locator(editor_selector).click({ delay: 500 });
+
+	// at this time, expect focus to be on the editor
+	await expect(page.locator(editor_focus_selector)).toBeFocused();
+
+	// wait for the iframe to load
+	await page.frameLocator(iframe_selector).getByText('Hello world!').waitFor();
+
+	// wait a little, because there may be a script that manipulates focus
+	await page.waitForTimeout(1000);
+
+	// expect focus to be on the editor
+	await expect(page.locator(editor_focus_selector)).toBeFocused();
+
+	await context.close();
+});
+
+test('focus management: input inside the iframe gets focus when clicking it', async () => {
+	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
+	const page = await context.newPage();
+
+	await page.goto('/tutorial/named-form-actions');
+
+	const iframe = page.frameLocator(iframe_selector);
+
+	// wait for the iframe to load
+	await iframe.getByText('todos').waitFor();
+
+	// first, focus the editor
+	await page.locator(editor_selector).click({ delay: 500 });
+	await expect(page.locator(editor_focus_selector)).toBeFocused();
+
+	// then, click a input in the iframe
+	const input = iframe.locator('input[name="description"]');
+	await input.click({ delay: 500 });
+
+	// wait a little, because there may be a script that manipulates focus
+	await page.waitForTimeout(1000);
+
+	// expect focus to be on the input in the iframe, not the editor.
+	await expect(input).toBeFocused();
+	await expect(page.locator(editor_focus_selector)).not.toBeFocused();
+
+	await context.close();
+});
+
+test('focus management: body inside the iframe gets focus when clicking a link inside the iframe', async () => {
+	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
+	const page = await context.newPage();
+
+	await page.goto('/tutorial/layouts');
+
+	const iframe = page.frameLocator(iframe_selector);
+
+	// wait for the iframe to load
+	await iframe.getByText('this is the home page.').waitFor();
+
+	// first, focus the editor
+	await page.locator(editor_selector).click({ delay: 500 });
+	await expect(page.locator(editor_focus_selector)).toBeFocused();
+
+	// then, click a link in the iframe
+	await iframe.locator('a[href="/about"]').click({ delay: 500 });
+
+	// wait for navigation
+	await iframe.getByText('this is the about page.').waitFor();
+
+	// wait a little, because there may be a script that manipulates focus
+	await page.waitForTimeout(1000);
+
+	// expect focus to be on body in the iframe, not the editor.
+	await expect(iframe.locator('body')).toBeFocused();
+
+	await context.close();
+});
+
+test('focus management: the editor keeps focus while typing', async () => {
+	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
+	const page = await context.newPage();
+
+	await page.goto('/tutorial/your-first-component');
+
+	// wait for the iframe to load
+	await page.frameLocator(iframe_selector).getByText('Hello world!').waitFor();
+
+	// first, write script tag
+	const code = '<script>\n\n</script>\n';
+	await page.locator(editor_focus_selector).fill(code);
+
+	// move the cursor into the script tag
+	await page.keyboard.press('PageUp', { delay: 500 });
+	await page.keyboard.press('ArrowDown', { delay: 500 });
+
+	// wait a little because the above operation is flaky
+	await page.waitForTimeout(500);
+
+	// type the code as a person would do it manually
+	await page.keyboard.type(`	export let data;`, { delay: 100 });
+
+	// wait a little, because there may be a script that manipulates focus
+	await page.waitForTimeout(1000);
+
+	// get code from DOM, then replace nbsp with normal space
+	const received = (await page.locator(editor_selector).innerText()).replace(/\u00a0/g, ' ');
+
+	const expected = '<script>\n  export let data;\n</script>\n<h1>Hello world!</h1>';
+
+	expect(received).toBe(expected);
+
+	await context.close();
+});


### PR DESCRIPTION
refs: https://github.com/sveltejs/learn.svelte.dev/pull/190#issuecomment-1405050141, https://github.com/sveltejs/learn.svelte.dev/pull/190#issuecomment-1405322111

typed `export let data;`, but entered `export let dat;`. The `a` is missing.
So, I will create tests to not introduce regressions, and fix this issue.

https://user-images.githubusercontent.com/29677552/214850880-cb09cf60-ab7d-4f74-ade7-a6e2bf25bbd9.mov

