### PR TITLE
fix: add scripts to each package.json

### DIFF
--- a/content/tutorial/01-svelte/06-bindings/05-textarea-inputs/app-a/package.json
+++ b/content/tutorial/01-svelte/06-bindings/05-textarea-inputs/app-a/package.json
@@ -1,6 +1,11 @@
 {
 	"name": "~TODO~",
 	"version": "0.0.1",
+	"scripts": {
+		"dev": "./node_modules/vite/bin/vite.js dev",
+		"build": "./node_modules/vite/bin/vite.js build",
+		"preview": "./node_modules/vite/bin/vite.js preview"
+	},
 	"dependencies": {
 		"marked": "^4.0.16"
 	},

--- a/content/tutorial/01-svelte/07-lifecycle/03-update/app-a/package.json
+++ b/content/tutorial/01-svelte/07-lifecycle/03-update/app-a/package.json
@@ -1,6 +1,11 @@
 {
 	"name": "~TODO~",
 	"version": "0.0.1",
+	"scripts": {
+		"dev": "./node_modules/vite/bin/vite.js dev",
+		"build": "./node_modules/vite/bin/vite.js build",
+		"preview": "./node_modules/vite/bin/vite.js preview"
+	},
 	"dependencies": {
 		"elizabot": "^0.0.3"
 	},

--- a/scripts/create-common-bundle/unzip.js
+++ b/scripts/create-common-bundle/unzip.js
@@ -4,7 +4,9 @@ import AdmZip from 'adm-zip';
 const zip = new AdmZip('common.zip');
 zip.extractAllTo('.');
 
-fs.existsSync('node_modules/.bin') || fs.mkdirSync('node_modules/.bin');
+if (!fs.existsSync('node_modules/.bin')) {
+	fs.mkdirSync('node_modules/.bin');
+}
 
 fs.symlinkSync('../@sveltejs/kit/svelte-kit.js', 'node_modules/.bin/svelte-kit');
 fs.chmodSync('node_modules/.bin/svelte-kit', 0o777);

--- a/scripts/create-common-bundle/unzip.js
+++ b/scripts/create-common-bundle/unzip.js
@@ -4,7 +4,7 @@ import AdmZip from 'adm-zip';
 const zip = new AdmZip('common.zip');
 zip.extractAllTo('.');
 
-fs.mkdirSync('node_modules/.bin');
+fs.existsSync('node_modules/.bin') || fs.mkdirSync('node_modules/.bin');
 
 fs.symlinkSync('../@sveltejs/kit/svelte-kit.js', 'node_modules/.bin/svelte-kit');
 fs.chmodSync('node_modules/.bin/svelte-kit', 0o777);


### PR DESCRIPTION
fix #178 

This is because the `dev` script is not present in each package.json when running `turbo run dev` in the background.
https://github.com/sveltejs/learn.svelte.dev/blob/7f6d1d31486902000965fcdcca9065c38fb9af7b/src/lib/client/adapters/webcontainer/index.js#L86

The same issue also occurs at https://learn.svelte.dev/tutorial/textarea-inputs, but there is another issue here.


<img width="1093" alt="image" src="https://user-images.githubusercontent.com/29677552/216340702-ffc7b4e6-1b3c-4fab-b945-451879a8473a.png">

This PR fixes both issues.
