### PR TITLE
fix: not to remove node_modules

### DIFF
--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -138,8 +138,8 @@ export async function create(stubs, callback) {
 				current_stubs.delete(stub.name);
 			}
 
-			// Hack: don't delete the node_modules folder when switching from one exercise to another
-			// where it's no longer needed, as this crashes the dev server.
+			// Don't delete the node_modules folder when switching from one exercise to another
+			// where, as this crashes the dev server.
 			['/node_modules', '/node_modules/.bin'].forEach((name) => current_stubs.delete(name));
 
 			const to_delete = Array.from(current_stubs.keys());

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -138,6 +138,9 @@ export async function create(stubs, callback) {
 				current_stubs.delete(stub.name);
 			}
 
+			const common_hidden_stubs = ['/node_modules', '/node_modules/.bin'];
+			common_hidden_stubs.forEach((name) => current_stubs.delete(name));
+
 			const to_delete = Array.from(current_stubs.keys());
 			current_stubs = stubs_to_map(stubs);
 

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -138,8 +138,9 @@ export async function create(stubs, callback) {
 				current_stubs.delete(stub.name);
 			}
 
-			const common_hidden_stubs = ['/node_modules', '/node_modules/.bin'];
-			common_hidden_stubs.forEach((name) => current_stubs.delete(name));
+			// Hack: don't delete the node_modules folder when switching from one exercise to another
+			// where it's no longer needed, as this crashes the dev server.
+			['/node_modules', '/node_modules/.bin'].forEach((name) => current_stubs.delete(name));
 
 			const to_delete = Array.from(current_stubs.keys());
 			current_stubs = stubs_to_map(stubs);


### PR DESCRIPTION
fix #195 

This is due to `node_modules` being removed when switching tutorials. This only happens when switching from one tutorial with its own `node_modules` to another.

https://github.com/sveltejs/learn.svelte.dev/blob/7f6d1d31486902000965fcdcca9065c38fb9af7b/src/lib/client/adapters/webcontainer/index.js#L141

https://github.com/sveltejs/learn.svelte.dev/blob/7f6d1d31486902000965fcdcca9065c38fb9af7b/src/lib/client/adapters/webcontainer/index.js#L170-L172


This PR is only an ad-hoc fix, but I submit it because I suppose it would be better than the tutorial not working.