### PR TITLE
fix: restart Vite if tutorial has a .env file

### DIFF
--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -183,6 +183,7 @@ export async function create(stubs, callback) {
 			// are not available until Vite is restarted. By creating a dummy `.env` file, it will
 			// be recognized as changed when the real `.env` file is loaded into the Webcontainer.
 			// This will invoke a restart of Vite. Hacky but it works.
+			// TODO: remove when https://github.com/vitejs/vite/issues/12127 is closed
 			if (!previous_env && current_stubs.has('/.env')) {
 				await vm.run({ command: 'touch', args: ['.env']});
 			}

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -119,11 +119,6 @@ export async function create(stubs, callback) {
 			/** @type {import('$lib/types').Stub[]} */
 			const to_write = [];
 
-			/** @type {import('$lib/types').FileStub=} */
-			let previous_env;
-			/** @type {import('$lib/types').FileStub=} */
-			let new_env;
-
 			for (const stub of stubs) {
 				if (stub.type === 'file') {
 					const current = /** @type {import('$lib/types').FileStub} */ (
@@ -132,11 +127,6 @@ export async function create(stubs, callback) {
 
 					if (current?.contents !== stub.contents) {
 						to_write.push(stub);
-					}
-
-					if (stub.name === '/.env') {
-						previous_env = current;
-						new_env = stub;
 					}
 
 					if (!current) added_new_file = true;
@@ -158,7 +148,7 @@ export async function create(stubs, callback) {
 			// For some reason, server-ready is fired again when the vite dev server is restarted.
 			// We need to wait for it to finish before we can continue, else we might
 			// request files from Vite before it's ready, leading to a timeout.
-			const will_restart = will_restart_vite_dev_server(to_write, previous_env, new_env);
+			const will_restart = will_restart_vite_dev_server(to_write);
 			const promise = will_restart
 				? new Promise((fulfil, reject) => {
 						const error_unsub = vm.on('error', (error) => {
@@ -201,20 +191,7 @@ export async function create(stubs, callback) {
 			/** @type {import('@webcontainer/api').FileSystemTree} */
 			const root = {};
 
-			/** @type {import('$lib/types').FileStub=} */
-			let previous_env;
-			/** @type {import('$lib/types').FileStub=} */
-			let new_env;
-
 			for (const stub of stubs) {
-
-				if (stub.name === '/.env') {
-					previous_env = /** @type {import('$lib/types').FileStub=} */ (
-						current_stubs.get('/.env')
-					);
-					new_env = stub;
-				}
-
 				let tree = root;
 
 				const path = stub.name.split('/').slice(1);
@@ -242,7 +219,7 @@ export async function create(stubs, callback) {
 
 			await new Promise((f) => setTimeout(f, 200)); // wait for chokidar
 
-			return will_restart_vite_dev_server(stubs, previous_env, new_env);
+			return will_restart_vite_dev_server(stubs);
 		},
 		destroy: async () => {
 			vm.teardown();
@@ -254,20 +231,14 @@ export async function create(stubs, callback) {
 
 /**
  * @param {import('$lib/types').Stub[]} stubs
- * @param {import('$lib/types').FileStub=} previous_env
- * @param {import('$lib/types').FileStub=} new_env
  */
-function will_restart_vite_dev_server(stubs, previous_env, new_env) {
-
-	if (previous_env && new_env && previous_env.contents !== new_env.contents) {
-		return true;
-	}
-
+function will_restart_vite_dev_server(stubs) {
 	return stubs.some(
 		(stub) =>
 			stub.type === 'file' &&
 			(stub.name === '/vite.config.js' ||
-				stub.name === '/svelte.config.js')
+				stub.name === '/svelte.config.js' ||
+				stub.name === '/.env')
 	);
 }
 

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -116,6 +116,10 @@ export async function create(stubs, callback) {
 
 			let added_new_file = false;
 
+			const previous_env = /** @type {import('$lib/types').FileStub=} */ (
+				current_stubs.get('/.env')
+			);
+
 			/** @type {import('$lib/types').Stub[]} */
 			const to_write = [];
 
@@ -173,6 +177,14 @@ export async function create(stubs, callback) {
 
 			for (const file of to_delete) {
 				await vm.fs.rm(file, { force: true, recursive: true });
+			}
+
+			// Adding a `.env` file does not restart Vite, but environment variables from `.env`
+			// are not available until Vite is restarted. By creating a dummy `.env` file, it will
+			// be recognized as changed when the real `.env` file is loaded into the Webcontainer.
+			// This will invoke a restart of Vite. Hacky but it works.
+			if (!previous_env && current_stubs.has('/.env')) {
+				await vm.run({ command: 'touch', args: ['.env']});
 			}
 
 			await vm.loadFiles(convert_stubs_to_tree(to_write));

--- a/tests/env_file.spec.ts
+++ b/tests/env_file.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test, chromium } from '@playwright/test';
+
+const chromium_flags = ['--enable-features=SharedArrayBuffer'];
+
+const iframe_selector = 'iframe[src*="webcontainer.io/"]';
+
+test('.env file: no timeout error occurs when switching a tutorials without a .env file to one with it', async () => {
+	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
+	const page = context.pages()[0];
+	await page.bringToFront();
+
+	await page.goto('/tutorial/welcome-to-svelte');
+
+	const iframe_locator = page.frameLocator(iframe_selector);
+
+	// wait for the iframe to load
+	await iframe_locator.getByText('Welcome!').waitFor();
+
+	// switch to another tutorial with a .env file
+	await page.click('header > h1', { delay: 200 });
+	await page.locator('button', { hasText: 'Part 4: Advanced SvelteKit' }).click({ delay: 200});
+	await page.locator('button', { hasText: 'Environment variables' }).click({ delay: 200});
+	await page.locator('a', { hasText: '$env/static/private' }).click({ delay: 200});
+
+	// wait for the iframe to load
+	await iframe_locator.getByText('enter the passphrase').waitFor();
+
+	// wait for a bit, because when Vite dev server is restarted, learn.svelte.dev
+	// will wait for 10 seconds, after which time a timeout error will occur.
+	await page.waitForTimeout(11000);
+
+	// expect no timeout error
+	await expect(page.getByText('Yikes!')).toBeHidden();
+	await expect(iframe_locator.getByText('enter the passphrase')).toBeVisible();
+
+	await context.close();
+});
+
+test('.env file: environment variables are available when switching a tutorial without a .env file to one with it', async () => {
+	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
+	const page = context.pages()[0];
+	await page.bringToFront();
+
+	await page.goto('/tutorial/welcome-to-svelte');
+
+	const iframe_locator = page.frameLocator(iframe_selector);
+
+	// wait for the iframe to load
+	await iframe_locator.getByText('Welcome!').waitFor();
+
+	// switch to another tutorial with a .env file
+	await page.click('header > h1', { delay: 200 });
+	await page.locator('button', { hasText: 'Part 4: Advanced SvelteKit' }).click({ delay: 200});
+	await page.locator('button', { hasText: 'Environment variables' }).click({ delay: 200});
+	await page.locator('a', { hasText: '$env/dynamic/private' }).click({ delay: 200});
+
+	// wait for the iframe to load
+	await iframe_locator.getByText('enter the passphrase').waitFor();
+	await iframe_locator.locator('input[name="passphrase"]').waitFor();
+
+	await page.waitForTimeout(500);
+
+	// login
+	// 'open sesame' is the environment variables loaded from `.env` file
+	await iframe_locator.locator('input[name="passphrase"]').fill('open sesame');
+	await page.keyboard.press('Enter', { delay: 200 });
+
+	// expect to be able to login.
+	// Being able to log in means that environment variables are loaded.
+	await expect(iframe_locator.getByText('wrong passphrase!')).toBeHidden();
+	await expect(iframe_locator.locator('button', { hasText: 'log out'})).toBeEnabled();
+
+	await context.close();
+});


### PR DESCRIPTION
fixes #206 

There are two problems with #206.

For the first problem, as expected, learn.svelte.dev waits for Vite dev server to restart when a `.dev` file is also added, but Vite only restarts when the `.env` file is changed.

- Vite

https://github.com/vitejs/vite/blob/d953536aae448e2bea0f3a7cb3c0062b16d45597/packages/vite/src/node/server/index.ts#L486-L503

https://github.com/vitejs/vite/blob/d953536aae448e2bea0f3a7cb3c0062b16d45597/packages/vite/src/node/server/hmr.ts#L54-L72

- learn.svelte.dev

https://github.com/sveltejs/learn.svelte.dev/blob/1c3bebf6dd07596924066bf43edd20082700ce08/src/lib/client/adapters/webcontainer/index.js#L235-L243

So, you might assume that just make learn.svelte.dev not wait for Vite dev server to restart when a `.env` file is added, but that would not solve the second problem.

As for the second problem, it is due to Vite's behavior. That is, when a `.env` file is added, the Vite dev server must be restarted in order to make the environment variables loaded from the `.env` file available.

In other words, if switching to a tutorial with a `. env`  file, the Vite dev server must be restarted. However, I looked through the Vite documentation and could not find a way to restart Vite.

This PR fix is hacky, but it solves both problems. Of course, if you have a better idea, I would like to do so.

