### PR TITLE
[fix] remove redundant spaces

### DIFF
--- a/content/tutorial/01-svelte/06-bindings/03-checkbox-inputs/app-b/src/lib/App.svelte
+++ b/content/tutorial/01-svelte/06-bindings/03-checkbox-inputs/app-b/src/lib/App.svelte
@@ -19,4 +19,4 @@
 	</p>
 {/if}
 
-<button disabled={!yes}> Subscribe </button>
+<button disabled={!yes}>Subscribe</button>


### PR DESCRIPTION
Removed redundant whitespaces to make it consistent with `app-a` and docs code style in general