### PR TITLE
fix: cross-origin isolation for preview

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,18 @@
 import path from 'path';
 import { sveltekit } from '@sveltejs/kit/vite';
 
+const crossOriginIsolationForPreview = {
+	name: 'cross-origin-isolation-for-preview',
+	configurePreviewServer: (server) => {
+		server.middlewares.use((_, res, next) => {
+			res.setHeader('cross-origin-opener-policy', 'same-origin');
+			res.setHeader('cross-origin-embedder-policy', 'require-corp');
+			res.setHeader('cross-origin-resource-policy', 'cross-origin');
+			next();
+		});
+	}
+};
+
 /** @type {import('vite').UserConfig} */
 export default {
 	build: {
@@ -9,7 +21,10 @@ export default {
 
 	logLevel: 'info',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit(),
+		crossOriginIsolationForPreview
+	],
 
 	server: {
 		fs: {


### PR DESCRIPTION
fixes #213 

According to [Vite's documentation](https://vitejs.dev/config/preview-options.html#preview-headers), it seems that it is possible to add headers with the `preview.headers` option, but it doesn't seem to work. I fix it in [this workaround](https://github.com/vitejs/vite/issues/9864#issuecomment-1230560351) (the issue is as of Vite 3, but it is still valid in the current Vite 4).