### PR TITLE
Replace XSS abbreviation with Cross-Site Scripting and link to OWASP

### DIFF
--- a/content/tutorial/01-svelte/01-introduction/06-html-tags/README.md
+++ b/content/tutorial/01-svelte/01-introduction/06-html-tags/README.md
@@ -12,4 +12,4 @@ In Svelte, you do this with the special `{@html ...}` tag:
 <p>{+++@html+++ string}</p>
 ```
 
-> Svelte doesn't perform any sanitization of the expression inside `{@html ...}` before it gets inserted into the DOM. In other words, if you use this feature it's critical that you manually escape HTML that comes from sources you don't trust, otherwise you risk exposing your users to XSS attacks.
+> Svelte doesn't perform any sanitization of the expression inside `{@html ...}` before it gets inserted into the DOM. In other words, if you use this feature it's critical that you manually escape HTML that comes from sources you don't trust, otherwise you risk exposing your users to <a href="https://owasp.org/www-community/attacks/xss/" target="_blank">Cross-Site Scripting</a> attacks.

--- a/content/tutorial/01-svelte/01-introduction/06-html-tags/README.md
+++ b/content/tutorial/01-svelte/01-introduction/06-html-tags/README.md
@@ -12,4 +12,4 @@ In Svelte, you do this with the special `{@html ...}` tag:
 <p>{+++@html+++ string}</p>
 ```
 
-> Svelte doesn't perform any sanitization of the expression inside `{@html ...}` before it gets inserted into the DOM. In other words, if you use this feature it's critical that you manually escape HTML that comes from sources you don't trust, otherwise you risk exposing your users to <a href="https://owasp.org/www-community/attacks/xss/" target="_blank">Cross-Site Scripting</a> attacks.
+> Svelte doesn't perform any sanitization of the expression inside `{@html ...}` before it gets inserted into the DOM. In other words, if you use this feature it's critical that you manually escape HTML that comes from sources you don't trust, otherwise you risk exposing your users to <a href="https://owasp.org/www-community/attacks/xss/" target="_blank">Cross-Site Scripting</a> (XSS) attacks.


### PR DESCRIPTION
Mainly for the benefit of less experienced programmers that may not be familiar with XSS vulnerabilites, I think replacing the abbreviation and linking to further information would be useful in driving this point home.