### PR TITLE
fix: setTimeout for time-consuming test

### DIFF
--- a/tests/env_file.spec.ts
+++ b/tests/env_file.spec.ts
@@ -5,6 +5,8 @@ const chromium_flags = ['--enable-features=SharedArrayBuffer'];
 const iframe_selector = 'iframe[src*="webcontainer.io/"]';
 
 test('.env file: no timeout error occurs when switching a tutorials without a .env file to one with it', async () => {
+	test.setTimeout(60000);
+
 	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
 	const page = context.pages()[0];
 	await page.bringToFront();


### PR DESCRIPTION
It seems that CI is failing because one of the tests I added is flaky, sorry.
By setting a longer timeout value for time-consuming tests, this problem can be alleviated.