### PR TITLE
refactor: playwright test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,8 @@ const config: PlaywrightTestConfig = {
 	webServer: {
 		command: 'pnpm preview',
 		port: 4173
-	}
+	},
+	timeout: 60000
 };
 
 export default config;

--- a/tests/env_file.spec.ts
+++ b/tests/env_file.spec.ts
@@ -1,76 +1,70 @@
-import { expect, test, chromium } from '@playwright/test';
-
-const chromium_flags = ['--enable-features=SharedArrayBuffer'];
+import { expect, test } from '@playwright/test';
 
 const iframe_selector = 'iframe[src*="webcontainer.io/"]';
 
-test('.env file: no timeout error occurs when switching a tutorials without a .env file to one with it', async () => {
-	test.setTimeout(60000);
+test.describe('.env file', () => {
+	test('no timeout error occurs when switching a tutorials without a .env file to one with it', async ({
+		page
+	}) => {
+		await page.bringToFront();
 
-	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
-	const page = context.pages()[0];
-	await page.bringToFront();
+		await page.goto('/tutorial/welcome-to-svelte');
 
-	await page.goto('/tutorial/welcome-to-svelte');
+		const iframe_locator = page.frameLocator(iframe_selector);
 
-	const iframe_locator = page.frameLocator(iframe_selector);
+		// wait for the iframe to load
+		await iframe_locator.getByText('Welcome!').waitFor();
 
-	// wait for the iframe to load
-	await iframe_locator.getByText('Welcome!').waitFor();
+		// switch to another tutorial with a .env file
+		await page.click('header > h1', { delay: 200 });
+		await page.locator('button', { hasText: 'Part 4: Advanced SvelteKit' }).click({ delay: 200 });
+		await page.locator('button', { hasText: 'Environment variables' }).click({ delay: 200 });
+		await page.locator('a', { hasText: '$env/static/private' }).click({ delay: 200 });
 
-	// switch to another tutorial with a .env file
-	await page.click('header > h1', { delay: 200 });
-	await page.locator('button', { hasText: 'Part 4: Advanced SvelteKit' }).click({ delay: 200});
-	await page.locator('button', { hasText: 'Environment variables' }).click({ delay: 200});
-	await page.locator('a', { hasText: '$env/static/private' }).click({ delay: 200});
+		// wait for the iframe to load
+		await iframe_locator.getByText('enter the passphrase').waitFor();
 
-	// wait for the iframe to load
-	await iframe_locator.getByText('enter the passphrase').waitFor();
+		// wait for a bit, because when Vite dev server is restarted, learn.svelte.dev
+		// will wait for 10 seconds, after which time a timeout error will occur.
+		await page.waitForTimeout(11000);
 
-	// wait for a bit, because when Vite dev server is restarted, learn.svelte.dev
-	// will wait for 10 seconds, after which time a timeout error will occur.
-	await page.waitForTimeout(11000);
+		// expect no timeout error
+		await expect(page.getByText('Yikes!')).toBeHidden();
+		await expect(iframe_locator.getByText('enter the passphrase')).toBeVisible();
+	});
 
-	// expect no timeout error
-	await expect(page.getByText('Yikes!')).toBeHidden();
-	await expect(iframe_locator.getByText('enter the passphrase')).toBeVisible();
+	test('environment variables are available when switching a tutorial without a .env file to one with it', async ({
+		page
+	}) => {
+		await page.bringToFront();
 
-	await context.close();
-});
+		await page.goto('/tutorial/welcome-to-svelte');
 
-test('.env file: environment variables are available when switching a tutorial without a .env file to one with it', async () => {
-	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
-	const page = context.pages()[0];
-	await page.bringToFront();
+		const iframe_locator = page.frameLocator(iframe_selector);
 
-	await page.goto('/tutorial/welcome-to-svelte');
+		// wait for the iframe to load
+		await iframe_locator.getByText('Welcome!').waitFor();
 
-	const iframe_locator = page.frameLocator(iframe_selector);
+		// switch to another tutorial with a .env file
+		await page.click('header > h1', { delay: 200 });
+		await page.locator('button', { hasText: 'Part 4: Advanced SvelteKit' }).click({ delay: 200 });
+		await page.locator('button', { hasText: 'Environment variables' }).click({ delay: 200 });
+		await page.locator('a', { hasText: '$env/dynamic/private' }).click({ delay: 200 });
 
-	// wait for the iframe to load
-	await iframe_locator.getByText('Welcome!').waitFor();
+		// wait for the iframe to load
+		await iframe_locator.getByText('enter the passphrase').waitFor();
+		await iframe_locator.locator('input[name="passphrase"]').waitFor();
 
-	// switch to another tutorial with a .env file
-	await page.click('header > h1', { delay: 200 });
-	await page.locator('button', { hasText: 'Part 4: Advanced SvelteKit' }).click({ delay: 200});
-	await page.locator('button', { hasText: 'Environment variables' }).click({ delay: 200});
-	await page.locator('a', { hasText: '$env/dynamic/private' }).click({ delay: 200});
+		await page.waitForTimeout(500);
 
-	// wait for the iframe to load
-	await iframe_locator.getByText('enter the passphrase').waitFor();
-	await iframe_locator.locator('input[name="passphrase"]').waitFor();
+		// login
+		// 'open sesame' is the environment variables loaded from `.env` file
+		await iframe_locator.locator('input[name="passphrase"]').fill('open sesame');
+		await page.keyboard.press('Enter', { delay: 400 });
 
-	await page.waitForTimeout(500);
-
-	// login
-	// 'open sesame' is the environment variables loaded from `.env` file
-	await iframe_locator.locator('input[name="passphrase"]').fill('open sesame');
-	await page.keyboard.press('Enter', { delay: 200 });
-
-	// expect to be able to login.
-	// Being able to log in means that environment variables are loaded.
-	await expect(iframe_locator.getByText('wrong passphrase!')).toBeHidden();
-	await expect(iframe_locator.locator('button', { hasText: 'log out'})).toBeEnabled();
-
-	await context.close();
+		// expect to be able to login.
+		// Being able to log in means that environment variables are loaded.
+		await expect(iframe_locator.getByText('wrong passphrase!')).toBeHidden();
+		await expect(iframe_locator.locator('button', { hasText: 'log out' })).toBeEnabled();
+	});
 });

--- a/tests/env_file.spec.ts
+++ b/tests/env_file.spec.ts
@@ -2,68 +2,66 @@ import { expect, test } from '@playwright/test';
 
 const iframe_selector = 'iframe[src*="webcontainer.io/"]';
 
-test.describe('.env file', () => {
-	test('no timeout error occurs when switching a tutorials without a .env file to one with it', async ({
-		page
-	}) => {
-		await page.bringToFront();
+test('.env file: no timeout error occurs when switching a tutorials without a .env file to one with it', async ({
+	page
+}) => {
+	await page.bringToFront();
 
-		await page.goto('/tutorial/welcome-to-svelte');
+	await page.goto('/tutorial/welcome-to-svelte');
 
-		const iframe_locator = page.frameLocator(iframe_selector);
+	const iframe_locator = page.frameLocator(iframe_selector);
 
-		// wait for the iframe to load
-		await iframe_locator.getByText('Welcome!').waitFor();
+	// wait for the iframe to load
+	await iframe_locator.getByText('Welcome!').waitFor();
 
-		// switch to another tutorial with a .env file
-		await page.click('header > h1', { delay: 200 });
-		await page.locator('button', { hasText: 'Part 4: Advanced SvelteKit' }).click({ delay: 200 });
-		await page.locator('button', { hasText: 'Environment variables' }).click({ delay: 200 });
-		await page.locator('a', { hasText: '$env/static/private' }).click({ delay: 200 });
+	// switch to another tutorial with a .env file
+	await page.click('header > h1', { delay: 200 });
+	await page.locator('button', { hasText: 'Part 4: Advanced SvelteKit' }).click({ delay: 200 });
+	await page.locator('button', { hasText: 'Environment variables' }).click({ delay: 200 });
+	await page.locator('a', { hasText: '$env/static/private' }).click({ delay: 200 });
 
-		// wait for the iframe to load
-		await iframe_locator.getByText('enter the passphrase').waitFor();
+	// wait for the iframe to load
+	await iframe_locator.getByText('enter the passphrase').waitFor();
 
-		// wait for a bit, because when Vite dev server is restarted, learn.svelte.dev
-		// will wait for 10 seconds, after which time a timeout error will occur.
-		await page.waitForTimeout(11000);
+	// wait for a bit, because when Vite dev server is restarted, learn.svelte.dev
+	// will wait for 10 seconds, after which time a timeout error will occur.
+	await page.waitForTimeout(11000);
 
-		// expect no timeout error
-		await expect(page.getByText('Yikes!')).toBeHidden();
-		await expect(iframe_locator.getByText('enter the passphrase')).toBeVisible();
-	});
+	// expect no timeout error
+	await expect(page.getByText('Yikes!')).toBeHidden();
+	await expect(iframe_locator.getByText('enter the passphrase')).toBeVisible();
+});
 
-	test('environment variables are available when switching a tutorial without a .env file to one with it', async ({
-		page
-	}) => {
-		await page.bringToFront();
+test('.env file: environment variables are available when switching a tutorial without a .env file to one with it', async ({
+	page
+}) => {
+	await page.bringToFront();
 
-		await page.goto('/tutorial/welcome-to-svelte');
+	await page.goto('/tutorial/welcome-to-svelte');
 
-		const iframe_locator = page.frameLocator(iframe_selector);
+	const iframe_locator = page.frameLocator(iframe_selector);
 
-		// wait for the iframe to load
-		await iframe_locator.getByText('Welcome!').waitFor();
+	// wait for the iframe to load
+	await iframe_locator.getByText('Welcome!').waitFor();
 
-		// switch to another tutorial with a .env file
-		await page.click('header > h1', { delay: 200 });
-		await page.locator('button', { hasText: 'Part 4: Advanced SvelteKit' }).click({ delay: 200 });
-		await page.locator('button', { hasText: 'Environment variables' }).click({ delay: 200 });
-		await page.locator('a', { hasText: '$env/dynamic/private' }).click({ delay: 200 });
+	// switch to another tutorial with a .env file
+	await page.click('header > h1', { delay: 200 });
+	await page.locator('button', { hasText: 'Part 4: Advanced SvelteKit' }).click({ delay: 200 });
+	await page.locator('button', { hasText: 'Environment variables' }).click({ delay: 200 });
+	await page.locator('a', { hasText: '$env/dynamic/private' }).click({ delay: 200 });
 
-		// wait for the iframe to load
-		await iframe_locator.getByText('enter the passphrase').waitFor();
+	// wait for the iframe to load
+	await iframe_locator.getByText('enter the passphrase').waitFor();
 
-		await page.waitForTimeout(3000);
+	await page.waitForTimeout(3000);
 
-		// login
-		// 'open sesame' is the environment variables loaded from `.env` file
-		await iframe_locator.locator('input[name="passphrase"]').fill('open sesame');
-		await page.keyboard.press('Enter', { delay: 1000 });
+	// login
+	// 'open sesame' is the environment variables loaded from `.env` file
+	await iframe_locator.locator('input[name="passphrase"]').fill('open sesame');
+	await page.keyboard.press('Enter', { delay: 1000 });
 
-		// expect to be able to login.
-		// Being able to log in means that environment variables are loaded.
-		await expect(iframe_locator.getByText('wrong passphrase!')).toBeHidden();
-		await expect(iframe_locator.locator('button', { hasText: 'log out' })).toBeEnabled();
-	});
+	// expect to be able to login.
+	// Being able to log in means that environment variables are loaded.
+	await expect(iframe_locator.getByText('wrong passphrase!')).toBeHidden();
+	await expect(iframe_locator.locator('button', { hasText: 'log out' })).toBeEnabled();
 });

--- a/tests/env_file.spec.ts
+++ b/tests/env_file.spec.ts
@@ -55,12 +55,12 @@ test.describe('.env file', () => {
 		await iframe_locator.getByText('enter the passphrase').waitFor();
 		await iframe_locator.locator('input[name="passphrase"]').waitFor();
 
-		await page.waitForTimeout(500);
+		await page.waitForTimeout(1000);
 
 		// login
 		// 'open sesame' is the environment variables loaded from `.env` file
 		await iframe_locator.locator('input[name="passphrase"]').fill('open sesame');
-		await page.keyboard.press('Enter', { delay: 400 });
+		await page.keyboard.press('Enter', { delay: 1000 });
 
 		// expect to be able to login.
 		// Being able to log in means that environment variables are loaded.

--- a/tests/env_file.spec.ts
+++ b/tests/env_file.spec.ts
@@ -53,9 +53,8 @@ test.describe('.env file', () => {
 
 		// wait for the iframe to load
 		await iframe_locator.getByText('enter the passphrase').waitFor();
-		await iframe_locator.locator('input[name="passphrase"]').waitFor();
 
-		await page.waitForTimeout(1000);
+		await page.waitForTimeout(3000);
 
 		// login
 		// 'open sesame' is the environment variables loaded from `.env` file

--- a/tests/focus_management.spec.ts
+++ b/tests/focus_management.spec.ts
@@ -4,113 +4,111 @@ const editor_selector = 'div.monaco-scrollable-element.editor-scrollable';
 const editor_focus_selector = 'textarea.inputarea.monaco-mouse-cursor-text';
 const iframe_selector = 'iframe[src*="webcontainer.io/"]';
 
-test.describe('focus management', () => {
-	test('the editor keeps focus when iframe is loaded', async ({ page }) => {
-		await page.bringToFront();
+test('focus management: the editor keeps focus when iframe is loaded', async ({ page }) => {
+	await page.bringToFront();
 
-		await page.goto('/tutorial/your-first-component');
+	await page.goto('/tutorial/your-first-component');
 
-		// first, focus the editor before the iframe is loaded
-		await page.locator(editor_selector).click({ delay: 1000 });
+	// first, focus the editor before the iframe is loaded
+	await page.locator(editor_selector).click({ delay: 1000 });
 
-		// at this time, expect focus to be on the editor
-		await expect(page.locator(editor_focus_selector)).toBeFocused();
+	// at this time, expect focus to be on the editor
+	await expect(page.locator(editor_focus_selector)).toBeFocused();
 
-		// wait for the iframe to load
-		await page.frameLocator(iframe_selector).getByText('Hello world!').waitFor();
+	// wait for the iframe to load
+	await page.frameLocator(iframe_selector).getByText('Hello world!').waitFor();
 
-		// wait a little, because there may be a script that manipulates focus
-		await page.waitForTimeout(1000);
+	// wait a little, because there may be a script that manipulates focus
+	await page.waitForTimeout(1000);
 
-		// expect focus to be on the editor
-		await expect(page.locator(editor_focus_selector)).toBeFocused();
-	});
+	// expect focus to be on the editor
+	await expect(page.locator(editor_focus_selector)).toBeFocused();
+});
 
-	test('input inside the iframe gets focus when clicking it', async ({ page }) => {
-		await page.bringToFront();
+test('focus management: input inside the iframe gets focus when clicking it', async ({ page }) => {
+	await page.bringToFront();
 
-		await page.goto('/tutorial/named-form-actions');
+	await page.goto('/tutorial/named-form-actions');
 
-		const iframe = page.frameLocator(iframe_selector);
+	const iframe = page.frameLocator(iframe_selector);
 
-		// wait for the iframe to load
-		await iframe.getByText('todos').waitFor();
+	// wait for the iframe to load
+	await iframe.getByText('todos').waitFor();
 
-		// first, focus the editor
-		await page.locator(editor_selector).click({ delay: 1000 });
-		await expect(page.locator(editor_focus_selector)).toBeFocused();
+	// first, focus the editor
+	await page.locator(editor_selector).click({ delay: 1000 });
+	await expect(page.locator(editor_focus_selector)).toBeFocused();
 
-		// then, click a input in the iframe
-		const input = iframe.locator('input[name="description"]');
-		await input.click({ delay: 1000 });
+	// then, click a input in the iframe
+	const input = iframe.locator('input[name="description"]');
+	await input.click({ delay: 1000 });
 
-		// wait a little, because there may be a script that manipulates focus
-		await page.waitForTimeout(1000);
+	// wait a little, because there may be a script that manipulates focus
+	await page.waitForTimeout(1000);
 
-		// expect focus to be on the input in the iframe, not the editor.
-		await expect(input).toBeFocused();
-		await expect(page.locator(editor_focus_selector)).not.toBeFocused();
-	});
+	// expect focus to be on the input in the iframe, not the editor.
+	await expect(input).toBeFocused();
+	await expect(page.locator(editor_focus_selector)).not.toBeFocused();
+});
 
-	test('body inside the iframe gets focus when clicking a link inside the iframe', async ({
-		page
-	}) => {
-		await page.bringToFront();
+test('focus management: body inside the iframe gets focus when clicking a link inside the iframe', async ({
+	page
+}) => {
+	await page.bringToFront();
 
-		await page.goto('/tutorial/layouts');
+	await page.goto('/tutorial/layouts');
 
-		const iframe = page.frameLocator(iframe_selector);
+	const iframe = page.frameLocator(iframe_selector);
 
-		// wait for the iframe to load
-		await iframe.getByText('this is the home page.').waitFor();
+	// wait for the iframe to load
+	await iframe.getByText('this is the home page.').waitFor();
 
-		// first, focus the editor
-		await page.locator(editor_selector).click({ delay: 1000 });
-		await expect(page.locator(editor_focus_selector)).toBeFocused();
+	// first, focus the editor
+	await page.locator(editor_selector).click({ delay: 1000 });
+	await expect(page.locator(editor_focus_selector)).toBeFocused();
 
-		// then, click a link in the iframe
-		await iframe.locator('a[href="/about"]').click({ delay: 500 });
+	// then, click a link in the iframe
+	await iframe.locator('a[href="/about"]').click({ delay: 500 });
 
-		// wait for navigation
-		await iframe.getByText('this is the about page.').waitFor();
+	// wait for navigation
+	await iframe.getByText('this is the about page.').waitFor();
 
-		// wait a little, because there may be a script that manipulates focus
-		await page.waitForTimeout(1000);
+	// wait a little, because there may be a script that manipulates focus
+	await page.waitForTimeout(1000);
 
-		// expect focus to be on body in the iframe, not the editor.
-		await expect(iframe.locator('body')).toBeFocused();
-	});
+	// expect focus to be on body in the iframe, not the editor.
+	await expect(iframe.locator('body')).toBeFocused();
+});
 
-	test('he editor keeps focus while typing', async ({ page }) => {
-		await page.bringToFront();
+test('focus management: The editor keeps focus while typing', async ({ page }) => {
+	await page.bringToFront();
 
-		await page.goto('/tutorial/your-first-component');
+	await page.goto('/tutorial/your-first-component');
 
-		// wait for the iframe to load
-		await page.frameLocator(iframe_selector).getByText('Hello world!').waitFor();
+	// wait for the iframe to load
+	await page.frameLocator(iframe_selector).getByText('Hello world!').waitFor();
 
-		// first, write script tag
-		const code = '<script>\n\n</script>\n';
-		await page.locator(editor_focus_selector).fill(code);
+	// first, write script tag
+	const code = '<script>\n\n</script>\n';
+	await page.locator(editor_focus_selector).fill(code);
 
-		// move the cursor into the script tag
-		await page.keyboard.press('PageUp', { delay: 500 });
-		await page.keyboard.press('ArrowDown', { delay: 500 });
+	// move the cursor into the script tag
+	await page.keyboard.press('PageUp', { delay: 500 });
+	await page.keyboard.press('ArrowDown', { delay: 500 });
 
-		// wait a little because the above operation is flaky
-		await page.waitForTimeout(500);
+	// wait a little because the above operation is flaky
+	await page.waitForTimeout(500);
 
-		// type the code as a person would do it manually
-		await page.keyboard.type(`	export let data;`, { delay: 150 });
+	// type the code as a person would do it manually
+	await page.keyboard.type(`	export let data;`, { delay: 150 });
 
-		// wait a little, because there may be a script that manipulates focus
-		await page.waitForTimeout(1000);
+	// wait a little, because there may be a script that manipulates focus
+	await page.waitForTimeout(1000);
 
-		// get code from DOM, then replace nbsp with normal space
-		const received = (await page.locator(editor_selector).innerText()).replace(/\u00a0/g, ' ');
+	// get code from DOM, then replace nbsp with normal space
+	const received = (await page.locator(editor_selector).innerText()).replace(/\u00a0/g, ' ');
 
-		const expected = '<script>\n  export let data;\n</script>\n<h1>Hello world!</h1>';
+	const expected = '<script>\n  export let data;\n</script>\n<h1>Hello world!</h1>';
 
-		expect(received).toBe(expected);
-	});
+	expect(received).toBe(expected);
 });

--- a/tests/focus_management.spec.ts
+++ b/tests/focus_management.spec.ts
@@ -1,130 +1,116 @@
-import { expect, test, chromium } from '@playwright/test';
-
-const chromium_flags = ['--enable-features=SharedArrayBuffer'];
+import { expect, test } from '@playwright/test';
 
 const editor_selector = 'div.monaco-scrollable-element.editor-scrollable';
 const editor_focus_selector = 'textarea.inputarea.monaco-mouse-cursor-text';
 const iframe_selector = 'iframe[src*="webcontainer.io/"]';
 
-test('focus management: the editor keeps focus when iframe is loaded', async () => {
-	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
-	const page = context.pages()[0];
-	await page.bringToFront();
+test.describe('focus management', () => {
+	test('the editor keeps focus when iframe is loaded', async ({ page }) => {
+		await page.bringToFront();
 
-	await page.goto('/tutorial/your-first-component');
+		await page.goto('/tutorial/your-first-component');
 
-	// first, focus the editor before the iframe is loaded
-	await page.locator(editor_selector).click({ delay: 1000 });
+		// first, focus the editor before the iframe is loaded
+		await page.locator(editor_selector).click({ delay: 1000 });
 
-	// at this time, expect focus to be on the editor
-	await expect(page.locator(editor_focus_selector)).toBeFocused();
+		// at this time, expect focus to be on the editor
+		await expect(page.locator(editor_focus_selector)).toBeFocused();
 
-	// wait for the iframe to load
-	await page.frameLocator(iframe_selector).getByText('Hello world!').waitFor();
+		// wait for the iframe to load
+		await page.frameLocator(iframe_selector).getByText('Hello world!').waitFor();
 
-	// wait a little, because there may be a script that manipulates focus
-	await page.waitForTimeout(1000);
+		// wait a little, because there may be a script that manipulates focus
+		await page.waitForTimeout(1000);
 
-	// expect focus to be on the editor
-	await expect(page.locator(editor_focus_selector)).toBeFocused();
+		// expect focus to be on the editor
+		await expect(page.locator(editor_focus_selector)).toBeFocused();
+	});
 
-	await context.close();
-});
+	test('input inside the iframe gets focus when clicking it', async ({ page }) => {
+		await page.bringToFront();
 
-test('focus management: input inside the iframe gets focus when clicking it', async () => {
-	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
-	const page = context.pages()[0];
-	await page.bringToFront();
+		await page.goto('/tutorial/named-form-actions');
 
-	await page.goto('/tutorial/named-form-actions');
+		const iframe = page.frameLocator(iframe_selector);
 
-	const iframe = page.frameLocator(iframe_selector);
+		// wait for the iframe to load
+		await iframe.getByText('todos').waitFor();
 
-	// wait for the iframe to load
-	await iframe.getByText('todos').waitFor();
+		// first, focus the editor
+		await page.locator(editor_selector).click({ delay: 1000 });
+		await expect(page.locator(editor_focus_selector)).toBeFocused();
 
-	// first, focus the editor
-	await page.locator(editor_selector).click({ delay: 1000 });
-	await expect(page.locator(editor_focus_selector)).toBeFocused();
+		// then, click a input in the iframe
+		const input = iframe.locator('input[name="description"]');
+		await input.click({ delay: 1000 });
 
-	// then, click a input in the iframe
-	const input = iframe.locator('input[name="description"]');
-	await input.click({ delay: 500 });
+		// wait a little, because there may be a script that manipulates focus
+		await page.waitForTimeout(1000);
 
-	// wait a little, because there may be a script that manipulates focus
-	await page.waitForTimeout(1000);
+		// expect focus to be on the input in the iframe, not the editor.
+		await expect(input).toBeFocused();
+		await expect(page.locator(editor_focus_selector)).not.toBeFocused();
+	});
 
-	// expect focus to be on the input in the iframe, not the editor.
-	await expect(input).toBeFocused();
-	await expect(page.locator(editor_focus_selector)).not.toBeFocused();
+	test('body inside the iframe gets focus when clicking a link inside the iframe', async ({
+		page
+	}) => {
+		await page.bringToFront();
 
-	await context.close();
-});
+		await page.goto('/tutorial/layouts');
 
-test('focus management: body inside the iframe gets focus when clicking a link inside the iframe', async () => {
-	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
-	const page = context.pages()[0];
-	await page.bringToFront();
+		const iframe = page.frameLocator(iframe_selector);
 
-	await page.goto('/tutorial/layouts');
+		// wait for the iframe to load
+		await iframe.getByText('this is the home page.').waitFor();
 
-	const iframe = page.frameLocator(iframe_selector);
+		// first, focus the editor
+		await page.locator(editor_selector).click({ delay: 1000 });
+		await expect(page.locator(editor_focus_selector)).toBeFocused();
 
-	// wait for the iframe to load
-	await iframe.getByText('this is the home page.').waitFor();
+		// then, click a link in the iframe
+		await iframe.locator('a[href="/about"]').click({ delay: 500 });
 
-	// first, focus the editor
-	await page.locator(editor_selector).click({ delay: 1000 });
-	await expect(page.locator(editor_focus_selector)).toBeFocused();
+		// wait for navigation
+		await iframe.getByText('this is the about page.').waitFor();
 
-	// then, click a link in the iframe
-	await iframe.locator('a[href="/about"]').click({ delay: 500 });
+		// wait a little, because there may be a script that manipulates focus
+		await page.waitForTimeout(1000);
 
-	// wait for navigation
-	await iframe.getByText('this is the about page.').waitFor();
+		// expect focus to be on body in the iframe, not the editor.
+		await expect(iframe.locator('body')).toBeFocused();
+	});
 
-	// wait a little, because there may be a script that manipulates focus
-	await page.waitForTimeout(1000);
+	test('he editor keeps focus while typing', async ({ page }) => {
+		await page.bringToFront();
 
-	// expect focus to be on body in the iframe, not the editor.
-	await expect(iframe.locator('body')).toBeFocused();
+		await page.goto('/tutorial/your-first-component');
 
-	await context.close();
-});
+		// wait for the iframe to load
+		await page.frameLocator(iframe_selector).getByText('Hello world!').waitFor();
 
-test('focus management: the editor keeps focus while typing', async () => {
-	const context = await chromium.launchPersistentContext('', { args: chromium_flags });
-	const page = context.pages()[0];
-	await page.bringToFront();
+		// first, write script tag
+		const code = '<script>\n\n</script>\n';
+		await page.locator(editor_focus_selector).fill(code);
 
-	await page.goto('/tutorial/your-first-component');
+		// move the cursor into the script tag
+		await page.keyboard.press('PageUp', { delay: 500 });
+		await page.keyboard.press('ArrowDown', { delay: 500 });
 
-	// wait for the iframe to load
-	await page.frameLocator(iframe_selector).getByText('Hello world!').waitFor();
+		// wait a little because the above operation is flaky
+		await page.waitForTimeout(500);
 
-	// first, write script tag
-	const code = '<script>\n\n</script>\n';
-	await page.locator(editor_focus_selector).fill(code);
+		// type the code as a person would do it manually
+		await page.keyboard.type(`	export let data;`, { delay: 150 });
 
-	// move the cursor into the script tag
-	await page.keyboard.press('PageUp', { delay: 500 });
-	await page.keyboard.press('ArrowDown', { delay: 500 });
+		// wait a little, because there may be a script that manipulates focus
+		await page.waitForTimeout(1000);
 
-	// wait a little because the above operation is flaky
-	await page.waitForTimeout(500);
+		// get code from DOM, then replace nbsp with normal space
+		const received = (await page.locator(editor_selector).innerText()).replace(/\u00a0/g, ' ');
 
-	// type the code as a person would do it manually
-	await page.keyboard.type(`	export let data;`, { delay: 100 });
+		const expected = '<script>\n  export let data;\n</script>\n<h1>Hello world!</h1>';
 
-	// wait a little, because there may be a script that manipulates focus
-	await page.waitForTimeout(1000);
-
-	// get code from DOM, then replace nbsp with normal space
-	const received = (await page.locator(editor_selector).innerText()).replace(/\u00a0/g, ' ');
-
-	const expected = '<script>\n  export let data;\n</script>\n<h1>Hello world!</h1>';
-
-	expect(received).toBe(expected);
-
-	await context.close();
+		expect(received).toBe(expected);
+	});
 });


### PR DESCRIPTION
Sorry to create PRs for tests again and again.

- remove `--enable-features=SharedArrayBuffer` flag (because #214 fixed it)
- set timeout in `playwright.config.ts`
- adjust delay time for flaky tests

The main body of each tests has changed very little.
I ran the tests six times on [GitHub Actions in the folk repository](https://github.com/svelte-jp/learn.svelte.dev/actions/runs/4240086360), and the flaky tests problem seems to have been alleviated.

The `env_file.spec.ts` could be removed once the test passes after [the Vite's issue](https://github.com/vitejs/vite/issues/12127) is fixed. I will submit another PR at that time.