### PR TITLE
Remove irrelevant change from tutorial

### DIFF
--- a/content/tutorial/01-svelte/07-lifecycle/02-ondestroy/app-b/src/lib/App.svelte
+++ b/content/tutorial/01-svelte/07-lifecycle/02-ondestroy/app-b/src/lib/App.svelte
@@ -1,7 +1,7 @@
 <script>
 	import Timer from './Timer.svelte';
 
-	let open = true;
+	let open = false;
 	let seconds = 0;
 
 	const toggle = () => (open = !open);


### PR DESCRIPTION
In `01-svelte/07-lifecycle/02-ondestroy` the boolean `open` switches value from `false` to `true`.

While solving the tutorial, I had to use the "solve" functionality in order to figure out what I was missing. This change of value seems irrelevant to the lesson itself and might bring confusion to others.