### PR TITLE
fix: prevent iframe from reloading when a folder is clicked

### DIFF
--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -2,7 +2,7 @@ import { derived, writable } from 'svelte/store';
 
 /**
  * @typedef {{
- *  status: 'initial' | 'select' | 'set' | 'update' | 'switch';
+ *  status: 'initial' | 'select' | 'set' | 'update' | 'switch' | 'expand';
  *  stubs: import("$lib/types").Stub[];
  *  last_updated?: import("$lib/types").FileStub;
  *  selected: string | null;
@@ -141,6 +141,7 @@ export const state = {
 	toggle_expanded: (name, expanded) => {
 		update((state) => ({
 			...state,
+			status: 'expand',
 			expanded: {
 				...state.expanded,
 				[name]: expanded ?? !state.expanded[name]


### PR DESCRIPTION
Immediately after opening learn.svelte.dev, if you click on the folder, the iframe will reload.

https://user-images.githubusercontent.com/29677552/224252481-a942d749-54c5-4061-98a2-db73268b74dc.mov

Note that I added `expand` to `status` for this fix, but it may not be the proper term (because I couldn't think of a better term with my poor English, sorry...).