### PR TITLE
overhaul adapter code

### DIFF
--- a/src/lib/client/adapters/filesystem/index.js
+++ b/src/lib/client/adapters/filesystem/index.js
@@ -1,7 +1,7 @@
 /**
  * @param {import('$lib/types').Stub[]} stubs
  * @param {(progress: number, status: string) => void} cb
- * @returns {Promise<import('$lib/types').AdapterInternal>}
+ * @returns {Promise<import('$lib/types').Adapter>}
  */
 export async function create(stubs, cb) {
 	const res = await fetch('/backend', {
@@ -56,10 +56,6 @@ export async function create(stubs, cb) {
 			await new Promise((f) => setTimeout(f, 100)); // wait for chokidar
 
 			return will_restart_vite_dev_server(stubs);
-		},
-
-		async destroy() {
-			navigator.sendBeacon(`/backend/destroy?id=${id}`);
 		}
 	};
 }

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -17,7 +17,7 @@ function console_stream(label) {
 
 /**
  * @param {(progress: number, status: string) => void} callback
- * @returns {Promise<import('$lib/types').AdapterInternal>}
+ * @returns {Promise<import('$lib/types').Adapter>}
  */
 export async function create(callback) {
 	if (/safari/i.test(navigator.userAgent) && !/chrome/i.test(navigator.userAgent)) {
@@ -219,9 +219,6 @@ export async function create(callback) {
 			await new Promise((f) => setTimeout(f, 200)); // wait for chokidar
 
 			return will_restart_vite_dev_server(stubs);
-		},
-		destroy: async () => {
-			vm.teardown();
 		}
 	};
 }

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -16,11 +16,10 @@ function console_stream(label) {
 }
 
 /**
- * @param {import('$lib/types').Stub[]} stubs
  * @param {(progress: number, status: string) => void} callback
  * @returns {Promise<import('$lib/types').AdapterInternal>}
  */
-export async function create(stubs, callback) {
+export async function create(callback) {
 	if (/safari/i.test(navigator.userAgent) && !/chrome/i.test(navigator.userAgent)) {
 		throw new Error('WebContainers are not supported by Safari');
 	}
@@ -35,7 +34,7 @@ export async function create(stubs, callback) {
 	let running;
 
 	/** Paths and contents of the currently loaded file stubs */
-	let current_stubs = stubs_to_map(stubs);
+	let current_stubs = stubs_to_map([]);
 
 	/** @type {boolean} Track whether there was an error from vite dev server */
 	let vite_error = false;
@@ -51,8 +50,7 @@ export async function create(stubs, callback) {
 		},
 		'unzip.cjs': {
 			file: { contents: common.unzip }
-		},
-		...convert_stubs_to_tree(stubs)
+		}
 	});
 
 	callback(3 / 5, 'unzipping files');

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -89,13 +89,7 @@ export async function create(stubs, callback) {
 			process.output.pipeTo(console_stream('dev'));
 
 			// keep restarting dev server (can crash in case of illegal +files for example)
-			process.exit.then((code) => {
-				if (code !== 0) {
-					setTimeout(() => {
-						run_dev();
-					}, 2000);
-				}
-			});
+			process.exit.then(run_dev);
 		}
 	});
 

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -182,7 +182,14 @@ export async function create(callback) {
 
 			// Also trigger a reload of the iframe in case new files were added / old ones deleted,
 			// because that can result in a broken UI state
-			return will_restart || vite_error || to_delete.length > 0 || added_new_file;
+			const should_reload = (
+				will_restart || 
+				vite_error ||
+				to_delete.length > 0
+				// `|| added_new_file`, but I don't actually think that's necessary?
+			);
+
+			return should_reload;
 		},
 		update: async (stubs) => {
 			await running;

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -104,7 +104,8 @@ export async function create(base, error, progress) {
 				process.output.pipeTo(console_stream('dev'));
 
 				// keep restarting dev server (can crash in case of illegal +files for example)
-				process.exit.then(run_dev);
+				await process.exit;
+				run_dev();
 			}
 		});
 	}

--- a/src/lib/client/adapters/webcontainer/index.js
+++ b/src/lib/client/adapters/webcontainer/index.js
@@ -200,13 +200,8 @@ export async function create(base, error, progress) {
 
 			// Also trigger a reload of the iframe in case new files were added / old ones deleted,
 			// because that can result in a broken UI state
-			const should_reload = (
-				!launched ||
-				will_restart || 
-				vite_error ||
-				to_delete.length > 0
-				// `|| added_new_file`, but I don't actually think that's necessary?
-			);
+			const should_reload = !launched || will_restart || vite_error || to_delete.length > 0;
+			// `|| added_new_file`, but I don't actually think that's necessary?
 
 			await launch();
 
@@ -253,10 +248,10 @@ export async function create(base, error, progress) {
  * @param {import('$lib/types').Stub} file
  */
 function will_restart_vite_dev_server(file) {
-	return file.type === 'file' &&
-			(file.name === '/vite.config.js' ||
-				file.name === '/svelte.config.js' ||
-				file.name === '/.env');
+	return (
+		file.type === 'file' &&
+		(file.name === '/vite.config.js' || file.name === '/svelte.config.js' || file.name === '/.env')
+	);
 }
 
 /**
@@ -284,11 +279,11 @@ function convert_stubs_to_tree(stubs, depth = 1) {
 	return tree;
 }
 
-/** @param {import('$lib/types').FileStub} stub */
-function to_file(stub) {
+/** @param {import('$lib/types').FileStub} file */
+function to_file(file) {
 	// special case
-	if (stub.name === '/src/app.html') {
-		const contents = stub.contents.replace(
+	if (file.name === '/src/app.html') {
+		const contents = file.contents.replace(
 			'</head>',
 			'<script type="module" src="/src/__client.js"></script></head>'
 		);
@@ -298,7 +293,7 @@ function to_file(stub) {
 		};
 	}
 
-	const contents = stub.text ? stub.contents : base64.toByteArray(stub.contents);
+	const contents = file.text ? file.contents : base64.toByteArray(file.contents);
 
 	return {
 		file: { contents }
@@ -306,12 +301,12 @@ function to_file(stub) {
 }
 
 /**
- * @param {import('$lib/types').Stub[]} stubs
+ * @param {import('$lib/types').Stub[]} files
  * @returns {Map<string, import('$lib/types').Stub>}
  */
-function stubs_to_map(stubs, map = new Map()) {
-	for (const stub of stubs) {
-		map.set(stub.name, stub);
+function stubs_to_map(files, map = new Map()) {
+	for (const file of files) {
+		map.set(file.name, file);
 	}
 	return map;
 }

--- a/src/lib/server/content.js
+++ b/src/lib/server/content.js
@@ -152,6 +152,37 @@ export function get_exercise(slug) {
 				};
 			}
 
+			const editing_constraints = {
+				create: new Set(exercise_meta.editing_constraints?.create ?? []),
+				remove: new Set(exercise_meta.editing_constraints?.remove ?? [])
+			};
+
+			const solution = { ...a };
+
+			// TODO should exercise.a/b be an array in the first place?
+			for (const stub of Object.values(b)) {
+				if (stub.type === 'file' && stub.contents.startsWith('__delete')) {
+					// remove file
+					editing_constraints.remove.add(stub.name);
+					delete solution[stub.name];
+				} else if (stub.name.endsWith('/__delete')) {
+					// remove directory
+					const parent = stub.name.slice(0, stub.name.lastIndexOf('/'));
+					editing_constraints.remove.add(parent);
+					delete solution[parent];
+					for (const k in solution) {
+						if (k.startsWith(parent + '/')) {
+							delete solution[k];
+						}
+					}
+				} else {
+					if (!solution[stub.name]) {
+						editing_constraints.create.add(stub.name);
+					}
+					solution[stub.name] = stub;
+				}
+			}
+
 			return {
 				part: {
 					slug: part_dir,
@@ -169,10 +200,7 @@ export function get_exercise(slug) {
 				prev,
 				next,
 				dir,
-				editing_constraints: {
-					create: new Set(exercise_meta.editing_constraints?.create ?? []),
-					remove: new Set(exercise_meta.editing_constraints?.remove ?? [])
-				},
+				editing_constraints,
 				html: transform(markdown, {
 					codespan: (text) =>
 						filenames.size > 1 && filenames.has(text)
@@ -180,7 +208,9 @@ export function get_exercise(slug) {
 							: `<code>${text}</code>`
 				}),
 				a,
-				b
+				b,
+				initial: Object.values(a),
+				solution: solution
 			};
 		}
 

--- a/src/lib/server/content.js
+++ b/src/lib/server/content.js
@@ -170,8 +170,8 @@ export function get_exercise(slug) {
 				next,
 				dir,
 				editing_constraints: {
-					create: exercise_meta.editing_constraints?.create ?? [],
-					remove: exercise_meta.editing_constraints?.remove ?? []
+					create: new Set(exercise_meta.editing_constraints?.create ?? []),
+					remove: new Set(exercise_meta.editing_constraints?.remove ?? [])
 				},
 				html: transform(markdown, {
 					codespan: (text) =>

--- a/src/lib/server/content.js
+++ b/src/lib/server/content.js
@@ -101,6 +101,7 @@ export function get_exercise(slug) {
 			}
 
 			const b = walk(`${dir}/app-b`);
+			const has_solution = Object.keys(b).length > 0;
 
 			const part_meta = json(`content/tutorial/${part_dir}/meta.json`);
 			const chapter_meta = json(`content/tutorial/${part_dir}/${chapter_dir}/meta.json`);
@@ -159,7 +160,6 @@ export function get_exercise(slug) {
 
 			const solution = { ...a };
 
-			// TODO should exercise.a/b be an array in the first place?
 			for (const stub of Object.values(b)) {
 				if (stub.type === 'file' && stub.contents.startsWith('__delete')) {
 					// remove file
@@ -208,9 +208,8 @@ export function get_exercise(slug) {
 							: `<code>${text}</code>`
 				}),
 				a,
-				b,
-				initial: Object.values(a),
-				solution: solution
+				b: solution,
+				has_solution
 			};
 		}
 
@@ -248,7 +247,7 @@ function extract_frontmatter(markdown, dir) {
  *   exclude?: string[]
  * }} options
  */
-export function walk(cwd, options = {}) {
+function walk(cwd, options = {}) {
 	/** @type {Record<string, import('$lib/types').FileStub | import('$lib/types').DirectoryStub>} */
 	const result = {};
 

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -27,7 +27,6 @@ export interface AdapterInternal {
 export interface Adapter extends AdapterInternal {
 	reset(files: Array<Stub>): Promise<boolean | 'cancelled'>;
 	update(file: Array<FileStub>): Promise<boolean | 'cancelled'>;
-	init: Promise<void>;
 }
 
 export interface Scope {

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -47,8 +47,8 @@ export interface Exercise {
 	html: string;
 	dir: string;
 	editing_constraints: {
-		create: string[];
-		remove: string[];
+		create: Set<string>;
+		remove: Set<string>;
 	};
 	a: Record<string, Stub>;
 	b: Record<string, Stub>;
@@ -72,6 +72,6 @@ export interface PartStub {
 }
 
 export interface EditingConstraints {
-	create: string[];
-	remove: string[];
+	create: Set<string>;
+	remove: Set<string>;
 }

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -52,10 +52,7 @@ export interface Exercise {
 	};
 	a: Record<string, Stub>;
 	b: Record<string, Stub>;
-
-	// TODO these are temporary — use a and b instead
-	initial: Stub[];
-	solution: Stub[];
+	has_solution: boolean;
 }
 
 export interface ExerciseStub {

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -20,7 +20,7 @@ export interface Adapter {
 	base: string;
 	/** Returns `false` if the reset was in such a way that a reload of the iframe isn't needed */
 	reset(files: Array<Stub>): Promise<boolean>;
-	update(file: Array<FileStub>): Promise<boolean>;
+	update(file: FileStub): Promise<boolean>;
 }
 
 export interface Scope {

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -17,7 +17,6 @@ export interface DirectoryStub {
 export type Stub = FileStub | DirectoryStub;
 
 export interface Adapter {
-	base: string;
 	/** Returns `false` if the reset was in such a way that a reload of the iframe isn't needed */
 	reset(files: Array<Stub>): Promise<boolean>;
 	update(file: FileStub): Promise<boolean>;

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -52,6 +52,10 @@ export interface Exercise {
 	};
 	a: Record<string, Stub>;
 	b: Record<string, Stub>;
+
+	// TODO these are temporary — use a and b instead
+	initial: Stub[];
+	solution: Stub[];
 }
 
 export interface ExerciseStub {

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -16,17 +16,11 @@ export interface DirectoryStub {
 
 export type Stub = FileStub | DirectoryStub;
 
-export interface AdapterInternal {
+export interface Adapter {
 	base: string;
 	/** Returns `false` if the reset was in such a way that a reload of the iframe isn't needed */
 	reset(files: Array<Stub>): Promise<boolean>;
 	update(file: Array<FileStub>): Promise<boolean>;
-	destroy(): Promise<void>;
-}
-
-export interface Adapter extends AdapterInternal {
-	reset(files: Array<Stub>): Promise<boolean | 'cancelled'>;
-	update(file: Array<FileStub>): Promise<boolean | 'cancelled'>;
 }
 
 export interface Scope {

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -72,7 +72,7 @@
 				<section slot="a">
 					<SplitPane type="horizontal" min="120px" max="300px" pos="200px">
 						<section class="navigator" slot="a">
-							<Filetree readonly={mobile} />
+							<Filetree readonly={mobile} scope={data.exercise.scope} />
 
 							<button
 								class:completed={$completed}

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -13,7 +13,7 @@
 	import Sidebar from './Sidebar.svelte';
 	import {
 		files,
-		set_stubs,
+		reset_files,
 		select_file,
 		selected_name,
 		selected_file,
@@ -122,7 +122,7 @@
 								class:completed
 								disabled={!data.exercise.has_solution}
 								on:click={() => {
-									set_stubs(Object.values(completed ? data.exercise.a : data.exercise.b));
+									reset_files(Object.values(completed ? data.exercise.a : data.exercise.b));
 								}}
 							>
 								{#if completed && data.exercise.has_solution}

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -79,7 +79,9 @@
 								disabled={Object.keys(data.exercise.b).length === 0}
 								on:click={() => {
 									state.set_stubs(
-										$completed ? $state.exercise.initial : Object.values($state.exercise.solution)
+										$completed
+											? Object.values(data.exercise.a)
+											: Object.values(data.exercise.solution)
 									);
 								}}
 							>

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -11,7 +11,15 @@
 	import ImageViewer from './ImageViewer.svelte';
 	import ScreenToggle from './ScreenToggle.svelte';
 	import Sidebar from './Sidebar.svelte';
-	import { files, state, selected_file, solution } from './state.js';
+	import {
+		files,
+		set_stubs,
+		select_file,
+		selected_name,
+		selected_file,
+		solution
+	} from './state.js';
+	import { reset } from './adapter.js';
 
 	export let data;
 
@@ -25,6 +33,11 @@
 
 	$: files.set(Object.values(data.exercise.a));
 	$: solution.set(data.exercise.b);
+	$: selected_name.set(data.exercise.focus);
+
+	afterNavigate(() => {
+		reset($files);
+	});
 
 	/**
 	 * @param {import('$lib/types').Stub[]} files
@@ -55,10 +68,6 @@
 		// TODO think about more sophisticated normalisation (e.g. truncate multiple newlines)
 		return code.replace(/\s+/g, ' ').trim();
 	}
-
-	afterNavigate(() => {
-		state.switch_exercise(data.exercise);
-	});
 </script>
 
 <svelte:head>
@@ -92,7 +101,7 @@
 				index={data.index}
 				exercise={data.exercise}
 				on:select={(e) => {
-					state.select_file(e.detail.file);
+					select_file(e.detail.file);
 				}}
 			/>
 		</section>
@@ -113,7 +122,7 @@
 								class:completed
 								disabled={!data.exercise.has_solution}
 								on:click={() => {
-									state.set_stubs(Object.values(completed ? data.exercise.a : data.exercise.b));
+									set_stubs(Object.values(completed ? data.exercise.a : data.exercise.b));
 								}}
 							>
 								{#if completed && data.exercise.has_solution}

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -78,7 +78,9 @@
 								class:completed={$completed}
 								disabled={Object.keys(data.exercise.b).length === 0}
 								on:click={() => {
-									state.toggle_completion();
+									state.set_stubs(
+										$completed ? $state.exercise.initial : Object.values($state.exercise.solution)
+									);
 								}}
 							>
 								{#if $completed && Object.keys(data.exercise.b).length > 0}

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -72,7 +72,7 @@
 				<section slot="a">
 					<SplitPane type="horizontal" min="120px" max="300px" pos="200px">
 						<section class="navigator" slot="a">
-							<Filetree readonly={mobile} scope={data.exercise.scope} />
+							<Filetree readonly={mobile} exercise={data.exercise} />
 
 							<button
 								class:completed={$completed}

--- a/src/routes/tutorial/[slug]/Editor.svelte
+++ b/src/routes/tutorial/[slug]/Editor.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { dev } from '$app/environment';
 	import { onMount } from 'svelte';
-	import { stubs, selected_name, update_file } from './state.js';
+	import { files, selected_name, update_file } from './state.js';
 
 	/**
 	 * file extension -> monaco language
@@ -141,11 +141,11 @@
 
 		/**
 		 *
-		 * @param {import('$lib/types').Stub[]} stubs
+		 * @param {import('$lib/types').Stub[]} files
 		 */
-		function update_files(stubs) {
+		function update_files(files) {
 			notify = false;
-			for (const stub of stubs) {
+			for (const stub of files) {
 				if (stub.type === 'directory') {
 					continue;
 				}
@@ -173,7 +173,7 @@
 			}
 
 			for (const [name, model] of models) {
-				if (!stubs.some((stub) => stub.name === name)) {
+				if (!files.some((stub) => stub.name === name)) {
 					model.dispose();
 					models.delete(name);
 				}
@@ -219,15 +219,15 @@
 	}
 
 	$: if (instance) {
-		instance.update_files($stubs);
+		instance.update_files($files);
 	}
 
 	$: if (instance) {
 		instance.editor.updateOptions({ readOnly: read_only });
 	}
 
-	$: if (instance && $stubs /* to retrigger on stubs change */) {
-		const model = $selected_name && models.get($selected_name);
+	$: if (instance && $files /* to retrigger on files change */) {
+		const model = $selected_name ? models.get($selected_name) : null;
 		instance.editor.setModel(model ?? null);
 	}
 

--- a/src/routes/tutorial/[slug]/Editor.svelte
+++ b/src/routes/tutorial/[slug]/Editor.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { dev } from '$app/environment';
 	import { onMount } from 'svelte';
-	import { stubs, selected, state } from './state.js';
+	import { stubs, selected_name, state } from './state.js';
 
 	/**
 	 * file extension -> monaco language
@@ -227,7 +227,7 @@
 	}
 
 	$: if (instance && $stubs /* to retrigger on stubs change */) {
-		const model = $selected && models.get($selected.name);
+		const model = $selected_name && models.get($selected_name);
 		instance.editor.setModel(model ?? null);
 	}
 

--- a/src/routes/tutorial/[slug]/Editor.svelte
+++ b/src/routes/tutorial/[slug]/Editor.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { dev } from '$app/environment';
 	import { onMount } from 'svelte';
-	import { stubs, selected_name, state } from './state.js';
+	import { stubs, selected_name, update_file } from './state.js';
 
 	/**
 	 * file extension -> monaco language
@@ -203,7 +203,7 @@
 
 				if (notify) {
 					stub.contents = contents;
-					state.update_file(stub);
+					update_file(stub);
 				}
 			});
 

--- a/src/routes/tutorial/[slug]/Output.svelte
+++ b/src/routes/tutorial/[slug]/Output.svelte
@@ -4,7 +4,7 @@
 	import { browser, dev } from '$app/environment';
 	import Chrome from './Chrome.svelte';
 	import Loading from './Loading.svelte';
-	import { create_adapter } from './adapter';
+	import { adapter, progress } from './adapter';
 	import { state } from './state.js';
 
 	/** @type {string} */
@@ -18,18 +18,7 @@
 	/** @type {Error | null} */
 	let error = null;
 
-	let progress = 0;
-	let status = 'initialising';
-
-	/** @type {import('$lib/types').Adapter} Will be defined after first afterNavigate */
-	let adapter;
-
 	onMount(() => {
-		adapter = create_adapter((p, s) => {
-			progress = p;
-			status = s;
-		});
-
 		const unsub = state.subscribe(async (state) => {
 			if (state.status === 'set' || state.status === 'switch') {
 				loading = true;
@@ -54,9 +43,6 @@
 
 		function destroy() {
 			unsub();
-			if (adapter) {
-				adapter.destroy();
-			}
 		}
 
 		document.addEventListener('pagehide', destroy);
@@ -184,7 +170,7 @@
 	{/if}
 
 	{#if loading || error}
-		<Loading {initial} {error} {progress} {status} />
+		<Loading {initial} {error} progress={$progress.value} status={$progress.text} />
 	{/if}
 </div>
 

--- a/src/routes/tutorial/[slug]/Output.svelte
+++ b/src/routes/tutorial/[slug]/Output.svelte
@@ -76,12 +76,11 @@
 				reload_iframe = result || state.status === 'switch';
 			}
 		} else {
-			const _adapter = create_adapter(state.stubs, (p, s) => {
+			adapter = create_adapter(state.stubs, (p, s) => {
 				progress = p;
 				status = s;
 			});
-			adapter = _adapter;
-			await _adapter.init;
+			await adapter.init;
 
 			set_iframe_src(adapter.base + path);
 		}

--- a/src/routes/tutorial/[slug]/Output.svelte
+++ b/src/routes/tutorial/[slug]/Output.svelte
@@ -22,12 +22,9 @@
 		// this is for HMR purposes
 		if ($base) set_iframe_src($base + path);
 
-		function destroy() {
+		return () => {
 			unsubscribe();
-		}
-
-		document.addEventListener('pagehide', destroy);
-		return destroy;
+		};
 	});
 
 	afterNavigate(() => {

--- a/src/routes/tutorial/[slug]/Output.svelte
+++ b/src/routes/tutorial/[slug]/Output.svelte
@@ -25,6 +25,11 @@
 	let adapter;
 
 	onMount(() => {
+		adapter = create_adapter((p, s) => {
+			progress = p;
+			status = s;
+		});
+
 		const unsub = state.subscribe(async (state) => {
 			if (state.status === 'set' || state.status === 'switch') {
 				loading = true;
@@ -68,21 +73,12 @@
 	 */
 	async function reset_adapter(state) {
 		let reload_iframe = true;
-		if (adapter) {
-			const result = await adapter.reset(state.stubs);
-			if (result === 'cancelled') {
-				return;
-			} else {
-				reload_iframe = result || state.status === 'switch';
-			}
-		} else {
-			adapter = create_adapter(state.stubs, (p, s) => {
-				progress = p;
-				status = s;
-			});
-			await adapter.init;
 
-			set_iframe_src(adapter.base + path);
+		const result = await adapter.reset(state.stubs);
+		if (result === 'cancelled') {
+			return;
+		} else {
+			reload_iframe = result || state.status === 'switch';
 		}
 
 		await new Promise((fulfil, reject) => {

--- a/src/routes/tutorial/[slug]/Output.svelte
+++ b/src/routes/tutorial/[slug]/Output.svelte
@@ -19,6 +19,9 @@
 			set_iframe_src($base + path);
 		});
 
+		// this is for HMR purposes
+		if ($base) set_iframe_src($base + path);
+
 		function destroy() {
 			unsubscribe();
 		}

--- a/src/routes/tutorial/[slug]/Output.svelte
+++ b/src/routes/tutorial/[slug]/Output.svelte
@@ -43,6 +43,7 @@
 
 		if (e.data.type === 'ping') {
 			path = e.data.data.path ?? path;
+			loading = false;
 
 			clearTimeout(timeout);
 			timeout = setTimeout(() => {
@@ -73,7 +74,7 @@
 <svelte:window on:message={handle_message} />
 <Chrome
 	{path}
-	loading={$progress.value < 1}
+	{loading}
 	on:refresh={() => {
 		set_iframe_src($base + path);
 	}}
@@ -91,7 +92,7 @@
 		<iframe bind:this={iframe} title="Output" />
 	{/if}
 
-	{#if $progress.value < 1 || $error}
+	{#if loading || $error}
 		<Loading {initial} error={$error} progress={$progress.value} status={$progress.text} />
 	{/if}
 </div>

--- a/src/routes/tutorial/[slug]/adapter.js
+++ b/src/routes/tutorial/[slug]/adapter.js
@@ -1,3 +1,17 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+export const progress = writable({
+	value: 0,
+	text: 'initialising'
+});
+
+/** @type {import('$lib/types').Adapter} */
+// @ts-expect-error
+export const adapter = browser
+	? create_adapter((value, text) => { progress.set({ value, text }); })
+	: undefined;
+
 /**
  * @param {(progress: number, status: string) => void} callback
  * @returns {import('$lib/types').Adapter}
@@ -46,7 +60,6 @@ export function create_adapter(callback) {
 	current = init().then(() => true);
 
 	return {
-		init: current.then(() => {}),
 		get base() {
 			return adapter_base;
 		},

--- a/src/routes/tutorial/[slug]/adapter.js
+++ b/src/routes/tutorial/[slug]/adapter.js
@@ -1,9 +1,8 @@
 /**
- * @param {import('$lib/types').Stub[]} initial_stubs
  * @param {(progress: number, status: string) => void} callback
  * @returns {import('$lib/types').Adapter}
  */
-export function create_adapter(initial_stubs, callback) {
+export function create_adapter(callback) {
 	/**
 	 * @typedef {{ type: 'reset'; stubs: import('$lib/types').Stub[]; } | { type: 'update'; stubs: import('$lib/types').FileStub[]; }} State
 	 */
@@ -16,7 +15,7 @@ export function create_adapter(initial_stubs, callback) {
 
 	async function init() {
 		const module = await import('$lib/client/adapters/webcontainer/index.js');
-		adapter_promise = module.create(initial_stubs, callback);
+		adapter_promise = module.create(callback);
 		adapter_base = (await adapter_promise).base;
 	}
 

--- a/src/routes/tutorial/[slug]/adapter.js
+++ b/src/routes/tutorial/[slug]/adapter.js
@@ -6,84 +6,38 @@ export const progress = writable({
 	text: 'initialising'
 });
 
-/** @type {import('$lib/types').Adapter} */
-// @ts-expect-error
-export const adapter = browser
-	? create_adapter((value, text) => { progress.set({ value, text }); })
-	: undefined;
+/** @type {import('svelte/store').Writable<string | null>} */
+export const base = writable(null);
+
+let ready = new Promise(() => {});
+
+if (browser) {
+	ready = new Promise(async (fulfil, reject) => {
+		try {
+			const module = await import('$lib/client/adapters/webcontainer/index.js');
+			const adapter = await module.create((value, text) => { progress.set({ value, text }); });
+
+			base.set(adapter.base);
+
+			fulfil(adapter);
+		} catch (error) {
+			reject(error);
+		}
+	})
+}
 
 /**
- * @param {(progress: number, status: string) => void} callback
- * @returns {import('$lib/types').Adapter}
+ * @param {import('$lib/types').Stub[]} files 
  */
-export function create_adapter(callback) {
-	/**
-	 * @typedef {{ type: 'reset'; stubs: import('$lib/types').Stub[]; } | { type: 'update'; stubs: import('$lib/types').FileStub[]; }} State
-	 */
+export async function reset(files) {
+	const adapter = await ready;
+	return adapter.reset(files);
+}
 
-	/** @type {State | undefined} */
-	let state;
-	/** @type {Promise<import('$lib/types').AdapterInternal>} */
-	let adapter_promise;
-	let adapter_base = '';
-
-	async function init() {
-		const module = await import('$lib/client/adapters/webcontainer/index.js');
-		adapter_promise = module.create(callback);
-		adapter_base = (await adapter_promise).base;
-	}
-
-	// Keep track of what's currently running, and what's next
-	/** @type {Promise<boolean>} */
-	let current;
-	let token = {};
-	async function next() {
-		const current_token = (token = {});
-		await current;
-		if (current_token !== token || !state) return 'cancelled';
-
-		const _state = state;
-		state = undefined;
-		current = (async () => {
-			if (_state.type === 'reset') {
-				const adapter = await adapter_promise;
-				return await adapter.reset(_state.stubs);
-			} else {
-				const adapter = await adapter_promise;
-				return await adapter.update(_state.stubs);
-			}
-		})();
-
-		return current;
-	}
-
-	current = init().then(() => true);
-
-	return {
-		get base() {
-			return adapter_base;
-		},
-		update: async (stubs) => {
-			if (state) {
-				// add new stubs (which have up-to-date content) to existing stubs
-				const new_stubs = new Set(stubs.map((stub) => stub.name));
-				state = {
-					...state,
-					// @ts-expect-error TS doesn't understand that the union type will be well-formed
-					stubs: state.stubs.filter((stub) => !new_stubs.has(stub.name)).concat(stubs)
-				};
-			} else {
-				state = { type: 'update', stubs };
-			}
-			return next();
-		},
-		reset: async (stubs) => {
-			state = { type: 'reset', stubs };
-			return next();
-		},
-		destroy: async () => {
-			const adapter = await adapter_promise;
-			return adapter.destroy();
-		}
-	};
+/**
+ * @param {import('$lib/types').Stub[]} files 
+ */
+export async function update(files) {
+	const adapter = await ready;
+	return adapter.update(files);
 }

--- a/src/routes/tutorial/[slug]/adapter.js
+++ b/src/routes/tutorial/[slug]/adapter.js
@@ -19,12 +19,7 @@ if (browser) {
 	ready = new Promise(async (fulfil, reject) => {
 		try {
 			const module = await import('$lib/client/adapters/webcontainer/index.js');
-			const adapter = await module.create((value, text) => {
-				progress.set({ value, text });
-			});
-
-			base.set(adapter.base);
-			publish('reload');
+			const adapter = await module.create(base, error, progress);
 
 			fulfil(adapter);
 		} catch (error) {

--- a/src/routes/tutorial/[slug]/adapter.js
+++ b/src/routes/tutorial/[slug]/adapter.js
@@ -12,6 +12,7 @@ export const base = writable(null);
 /** @type {import('svelte/store').Writable<Error | null>} */
 export const error = writable(null);
 
+/** @type {Promise<import('$lib/types').Adapter>} */
 let ready = new Promise(() => {});
 
 if (browser) {
@@ -76,11 +77,11 @@ export async function reset(files) {
 }
 
 /**
- * @param {import('$lib/types').Stub[]} files 
+ * @param {import('$lib/types').FileStub} file
  */
-export async function update(files) {
+export async function update(file) {
 	const adapter = await ready;
-	const should_reload = await adapter.update(files);
+	const should_reload = await adapter.update(file);
 
 	if (should_reload) {
 		publish('reload');

--- a/src/routes/tutorial/[slug]/filetree/File.svelte
+++ b/src/routes/tutorial/[slug]/filetree/File.svelte
@@ -2,7 +2,7 @@
 	import * as context from './context.js';
 	import Item from './Item.svelte';
 	import file_icon from '$lib/icons/file.svg';
-	import { selected_name, solution, state } from '../state.js';
+	import { selected_name, select_file, solution } from '../state.js';
 
 	/** @type {import('$lib/types').FileStub} */
 	export let file;
@@ -45,7 +45,7 @@
 	icon={file_icon}
 	selected={file.name === $selected_name}
 	{actions}
-	on:click={() => state.select_file(file.name)}
+	on:click={() => select_file(file.name)}
 	on:edit={() => {
 		renaming = true;
 	}}

--- a/src/routes/tutorial/[slug]/filetree/File.svelte
+++ b/src/routes/tutorial/[slug]/filetree/File.svelte
@@ -2,7 +2,7 @@
 	import * as context from './context.js';
 	import Item from './Item.svelte';
 	import file_icon from '$lib/icons/file.svg';
-	import { selected, solution, state } from '../state.js';
+	import { selected_name, solution, state } from '../state.js';
 
 	/** @type {import('$lib/types').FileStub} */
 	export let file;
@@ -43,7 +43,7 @@
 	{renaming}
 	basename={file.basename}
 	icon={file_icon}
-	selected={file.name === $selected?.name}
+	selected={file.name === $selected_name}
 	{actions}
 	on:click={() => state.select_file(file.name)}
 	on:edit={() => {

--- a/src/routes/tutorial/[slug]/filetree/Filetree.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Filetree.svelte
@@ -1,8 +1,10 @@
 <script>
+	import { writable } from 'svelte/store';
 	import Folder from './Folder.svelte';
 	import * as context from './context.js';
 	import Modal from '$lib/components/Modal.svelte';
 	import { state, stubs, editing_constraints, solution, scope } from '../state.js';
+	import { afterNavigate } from '$app/navigation';
 
 	/** @type {import('svelte/store').Writable<boolean>} */
 	export let readonly;
@@ -11,7 +13,14 @@
 
 	const hidden = new Set(['__client.js', 'node_modules']);
 
+	const collapsed = writable({});
+	afterNavigate(() => {
+		collapsed.set({});
+	});
+
 	context.set({
+		collapsed,
+
 		readonly,
 
 		add: async (name, type) => {

--- a/src/routes/tutorial/[slug]/filetree/Filetree.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Filetree.svelte
@@ -3,7 +3,7 @@
 	import Folder from './Folder.svelte';
 	import * as context from './context.js';
 	import Modal from '$lib/components/Modal.svelte';
-	import { files, solution, state, stubs } from '../state.js';
+	import { files, solution, set_stubs, select_file, stubs } from '../state.js';
 	import { afterNavigate } from '$app/navigation';
 
 	/** @type {import('svelte/store').Writable<boolean>} */
@@ -56,12 +56,12 @@
 					contents: ''
 				};
 
-				state.select_file(stub.name);
+				select_file(stub.name);
 			} else {
 				stub = { type: 'directory', name, basename };
 			}
 
-			state.set_stubs([...$stubs, ...create_directories(name, $stubs), stub]);
+			set_stubs([...$stubs, ...create_directories(name, $stubs), stub]);
 		},
 
 		rename: async (to_rename, new_name) => {
@@ -97,7 +97,7 @@
 			to_rename.basename = /** @type {string} */ (new_full_name.split('/').pop());
 			to_rename.name = new_full_name;
 
-			state.set_stubs([...$stubs, ...create_directories(new_full_name, $stubs)]);
+			set_stubs([...$stubs, ...create_directories(new_full_name, $stubs)]);
 		},
 
 		remove: async (stub) => {
@@ -108,8 +108,8 @@
 				return;
 			}
 
-			state.select_file(null);
-			state.set_stubs(
+			select_file(null);
+			set_stubs(
 				$stubs.filter((s) => {
 					if (s === stub) return false;
 					if (s.name.startsWith(stub.name + '/')) return false;

--- a/src/routes/tutorial/[slug]/filetree/Filetree.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Filetree.svelte
@@ -3,11 +3,14 @@
 	import Folder from './Folder.svelte';
 	import * as context from './context.js';
 	import Modal from '$lib/components/Modal.svelte';
-	import { state, stubs, editing_constraints, solution, scope } from '../state.js';
+	import { state, stubs, editing_constraints, solution } from '../state.js';
 	import { afterNavigate } from '$app/navigation';
 
 	/** @type {import('svelte/store').Writable<boolean>} */
 	export let readonly;
+
+	/** @type {import('$lib/types').Scope} */
+	export let scope;
 
 	let modal_text = '';
 
@@ -165,12 +168,12 @@
 	}}
 >
 	<Folder
-		prefix={$scope.prefix}
+		prefix={scope.prefix}
 		depth={0}
 		directory={{
 			type: 'directory',
 			name: '',
-			basename: $scope.name
+			basename: scope.name
 		}}
 		files={$stubs.filter((stub) => !hidden.has(stub.basename))}
 	/>

--- a/src/routes/tutorial/[slug]/filetree/Filetree.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Filetree.svelte
@@ -27,10 +27,10 @@
 		readonly,
 
 		add: async (name, type) => {
-			if (!$solution[name] && !$editing_constraints.create.includes(name)) {
+			if (!$solution[name] && !$editing_constraints.create.has(name)) {
 				modal_text =
 					'Only the following files and folders are allowed to be created in this exercise:\n' +
-					$editing_constraints.create.join('\n');
+					Array.from($editing_constraints.create).join('\n');
 				return;
 			}
 
@@ -70,17 +70,17 @@
 				return;
 			}
 
-			if (!$solution[new_full_name] && !$editing_constraints.create.includes(new_full_name)) {
+			if (!$solution[new_full_name] && !$editing_constraints.create.has(new_full_name)) {
 				modal_text =
 					'Only the following files and folders are allowed to be created in this exercise:\n' +
-					$editing_constraints.create.join('\n');
+					Array.from($editing_constraints.create).join('\n');
 				return;
 			}
 
-			if ($solution[to_rename.name] && !$editing_constraints.remove.includes(to_rename.name)) {
+			if ($solution[to_rename.name] && !$editing_constraints.remove.has(to_rename.name)) {
 				modal_text =
 					'Only the following files and folders are allowed to be removed in this exercise:\n' +
-					$editing_constraints.remove.join('\n');
+					Array.from($editing_constraints.remove).join('\n');
 				return;
 			}
 
@@ -99,10 +99,10 @@
 		},
 
 		remove: async (stub) => {
-			if ($solution[stub.name] && !$editing_constraints.remove.includes(stub.name)) {
+			if ($solution[stub.name] && !$editing_constraints.remove.has(stub.name)) {
 				modal_text =
 					'Only the following files and folders are allowed to be deleted in this tutorial chapter:\n' +
-					$editing_constraints.remove.join('\n');
+					Array.from($editing_constraints.remove).join('\n');
 				return;
 			}
 

--- a/src/routes/tutorial/[slug]/filetree/Filetree.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Filetree.svelte
@@ -3,7 +3,7 @@
 	import Folder from './Folder.svelte';
 	import * as context from './context.js';
 	import Modal from '$lib/components/Modal.svelte';
-	import { state, stubs, solution } from '../state.js';
+	import { files, solution, state, stubs } from '../state.js';
 	import { afterNavigate } from '$app/navigation';
 
 	/** @type {import('svelte/store').Writable<boolean>} */
@@ -16,7 +16,9 @@
 
 	const hidden = new Set(['__client.js', 'node_modules']);
 
+	/** @type {import('svelte/store').Writable<Record<string, boolean>>}*/
 	const collapsed = writable({});
+
 	afterNavigate(() => {
 		collapsed.set({});
 	});
@@ -34,7 +36,7 @@
 				return;
 			}
 
-			const existing = $state.stubs.find((stub) => stub.name === name);
+			const existing = $files.find((stub) => stub.name === name);
 			if (existing) {
 				modal_text = `A ${existing.type} already exists with this name`;
 				return;

--- a/src/routes/tutorial/[slug]/filetree/Filetree.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Filetree.svelte
@@ -3,7 +3,7 @@
 	import Folder from './Folder.svelte';
 	import * as context from './context.js';
 	import Modal from '$lib/components/Modal.svelte';
-	import { state, stubs, editing_constraints, solution } from '../state.js';
+	import { state, stubs, solution } from '../state.js';
 	import { afterNavigate } from '$app/navigation';
 
 	/** @type {import('svelte/store').Writable<boolean>} */
@@ -11,6 +11,9 @@
 
 	/** @type {import('$lib/types').Scope} */
 	export let scope;
+
+	/** @type {import('$lib/types').Exercise} */
+	export let exercise;
 
 	let modal_text = '';
 
@@ -27,10 +30,10 @@
 		readonly,
 
 		add: async (name, type) => {
-			if (!$solution[name] && !$editing_constraints.create.has(name)) {
+			if (!$solution[name] && !exercise.editing_constraints.create.has(name)) {
 				modal_text =
 					'Only the following files and folders are allowed to be created in this exercise:\n' +
-					Array.from($editing_constraints.create).join('\n');
+					Array.from(exercise.editing_constraints.create).join('\n');
 				return;
 			}
 
@@ -70,17 +73,17 @@
 				return;
 			}
 
-			if (!$solution[new_full_name] && !$editing_constraints.create.has(new_full_name)) {
+			if (!$solution[new_full_name] && !exercise.editing_constraints.create.has(new_full_name)) {
 				modal_text =
 					'Only the following files and folders are allowed to be created in this exercise:\n' +
-					Array.from($editing_constraints.create).join('\n');
+					Array.from(exercise.editing_constraints.create).join('\n');
 				return;
 			}
 
-			if ($solution[to_rename.name] && !$editing_constraints.remove.has(to_rename.name)) {
+			if ($solution[to_rename.name] && !exercise.editing_constraints.remove.has(to_rename.name)) {
 				modal_text =
 					'Only the following files and folders are allowed to be removed in this exercise:\n' +
-					Array.from($editing_constraints.remove).join('\n');
+					Array.from(exercise.editing_constraints.remove).join('\n');
 				return;
 			}
 
@@ -99,10 +102,10 @@
 		},
 
 		remove: async (stub) => {
-			if ($solution[stub.name] && !$editing_constraints.remove.has(stub.name)) {
+			if ($solution[stub.name] && !exercise.editing_constraints.remove.has(stub.name)) {
 				modal_text =
 					'Only the following files and folders are allowed to be deleted in this tutorial chapter:\n' +
-					Array.from($editing_constraints.remove).join('\n');
+					Array.from(exercise.editing_constraints.remove).join('\n');
 				return;
 			}
 

--- a/src/routes/tutorial/[slug]/filetree/Filetree.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Filetree.svelte
@@ -9,9 +9,6 @@
 	/** @type {import('svelte/store').Writable<boolean>} */
 	export let readonly;
 
-	/** @type {import('$lib/types').Scope} */
-	export let scope;
-
 	/** @type {import('$lib/types').Exercise} */
 	export let exercise;
 
@@ -171,12 +168,12 @@
 	}}
 >
 	<Folder
-		prefix={scope.prefix}
+		prefix={exercise.scope.prefix}
 		depth={0}
 		directory={{
 			type: 'directory',
 			name: '',
-			basename: scope.name
+			basename: exercise.scope.name
 		}}
 		files={$stubs.filter((stub) => !hidden.has(stub.basename))}
 	/>

--- a/src/routes/tutorial/[slug]/filetree/Filetree.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Filetree.svelte
@@ -3,7 +3,7 @@
 	import Folder from './Folder.svelte';
 	import * as context from './context.js';
 	import Modal from '$lib/components/Modal.svelte';
-	import { files, solution, set_stubs, select_file, stubs } from '../state.js';
+	import { files, solution, reset_files, select_file } from '../state.js';
 	import { afterNavigate } from '$app/navigation';
 
 	/** @type {import('svelte/store').Writable<boolean>} */
@@ -36,7 +36,7 @@
 				return;
 			}
 
-			const existing = $files.find((stub) => stub.name === name);
+			const existing = $files.find((file) => file.name === name);
 			if (existing) {
 				modal_text = `A ${existing.type} already exists with this name`;
 				return;
@@ -45,10 +45,10 @@
 			const basename = /** @type {string} */ (name.split('/').pop());
 
 			/** @type {import('$lib/types').Stub} */
-			let stub;
+			let file;
 
 			if (type === 'file') {
-				stub = {
+				file = {
 					type: 'file',
 					name,
 					basename,
@@ -56,18 +56,18 @@
 					contents: ''
 				};
 
-				select_file(stub.name);
+				select_file(file.name);
 			} else {
-				stub = { type: 'directory', name, basename };
+				file = { type: 'directory', name, basename };
 			}
 
-			set_stubs([...$stubs, ...create_directories(name, $stubs), stub]);
+			reset_files([...$files, ...create_directories(name, $files), file]);
 		},
 
 		rename: async (to_rename, new_name) => {
 			const new_full_name = to_rename.name.slice(0, -to_rename.basename.length) + new_name;
 
-			if ($stubs.some((s) => s.name === new_full_name)) {
+			if ($files.some((f) => f.name === new_full_name)) {
 				modal_text = `A file or folder named ${new_full_name} already exists`;
 				return;
 			}
@@ -87,9 +87,9 @@
 			}
 
 			if (to_rename.type === 'directory') {
-				for (const stub of $stubs) {
-					if (stub.name.startsWith(to_rename.name + '/')) {
-						stub.name = new_full_name + stub.name.slice(to_rename.name.length);
+				for (const file of $files) {
+					if (file.name.startsWith(to_rename.name + '/')) {
+						file.name = new_full_name + file.name.slice(to_rename.name.length);
 					}
 				}
 			}
@@ -97,11 +97,11 @@
 			to_rename.basename = /** @type {string} */ (new_full_name.split('/').pop());
 			to_rename.name = new_full_name;
 
-			set_stubs([...$stubs, ...create_directories(new_full_name, $stubs)]);
+			reset_files([...$files, ...create_directories(new_full_name, $files)]);
 		},
 
-		remove: async (stub) => {
-			if ($solution[stub.name] && !exercise.editing_constraints.remove.has(stub.name)) {
+		remove: async (file) => {
+			if ($solution[file.name] && !exercise.editing_constraints.remove.has(file.name)) {
 				modal_text =
 					'Only the following files and folders are allowed to be deleted in this tutorial chapter:\n' +
 					Array.from(exercise.editing_constraints.remove).join('\n');
@@ -109,10 +109,10 @@
 			}
 
 			select_file(null);
-			set_stubs(
-				$stubs.filter((s) => {
-					if (s === stub) return false;
-					if (s.name.startsWith(stub.name + '/')) return false;
+			reset_files(
+				$files.filter((f) => {
+					if (f === file) return false;
+					if (f.name.startsWith(file.name + '/')) return false;
 					return true;
 				})
 			);
@@ -121,14 +121,14 @@
 
 	/**
 	 * @param {string} name
-	 * @param {import('$lib/types').Stub[]} stubs
+	 * @param {import('$lib/types').Stub[]} files
 	 */
-	function create_directories(name, stubs) {
+	function create_directories(name, files) {
 		const existing = new Set();
 
-		for (const stub of stubs) {
-			if (stub.type === 'directory') {
-				existing.add(stub.name);
+		for (const file of files) {
+			if (file.type === 'directory') {
+				existing.add(file.name);
 			}
 		}
 
@@ -177,7 +177,7 @@
 			name: '',
 			basename: exercise.scope.name
 		}}
-		files={$stubs.filter((stub) => !hidden.has(stub.basename))}
+		contents={$files.filter((file) => !hidden.has(file.basename))}
 	/>
 </ul>
 

--- a/src/routes/tutorial/[slug]/filetree/Folder.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Folder.svelte
@@ -5,7 +5,7 @@
 	import Item from './Item.svelte';
 	import folder_closed from '$lib/icons/folder.svg';
 	import folder_open from '$lib/icons/folder-open.svg';
-	import { state, stubs, solution } from '../state.js';
+	import { stubs, solution } from '../state.js';
 
 	/** @type {import('$lib/types').DirectoryStub} */
 	export let directory;

--- a/src/routes/tutorial/[slug]/filetree/Folder.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Folder.svelte
@@ -5,7 +5,7 @@
 	import Item from './Item.svelte';
 	import folder_closed from '$lib/icons/folder.svg';
 	import folder_open from '$lib/icons/folder-open.svg';
-	import { stubs, solution } from '../state.js';
+	import { files, solution } from '../state.js';
 
 	/** @type {import('$lib/types').DirectoryStub} */
 	export let directory;
@@ -17,7 +17,7 @@
 	export let depth;
 
 	/** @type {Array<import('$lib/types').Stub>} */
-	export let files;
+	export let contents;
 
 	/** @type {'idle' | 'add_file' | 'add_directory' | 'renaming'} */
 	let mode = 'idle';
@@ -26,7 +26,7 @@
 
 	$: segments = get_depth(prefix);
 
-	$: children = files
+	$: children = contents
 		.filter((file) => file.name.startsWith(prefix))
 		.sort((a, b) => (a.name < b.name ? -1 : 1));
 
@@ -47,26 +47,26 @@
 		if (!$readonly) {
 			const child_prefixes = [];
 
-			for (const stub of $stubs) {
+			for (const file of $files) {
 				if (
-					stub.type === 'directory' &&
-					stub.name.startsWith(prefix) &&
-					get_depth(stub.name) === depth + 1
+					file.type === 'directory' &&
+					file.name.startsWith(prefix) &&
+					get_depth(file.name) === depth + 1
 				) {
-					child_prefixes.push(stub.name + '/');
+					child_prefixes.push(file.name + '/');
 				}
 			}
 
-			for (const stub of Object.values($solution)) {
-				if (!stub.name.startsWith(prefix)) continue;
+			for (const file of Object.values($solution)) {
+				if (!file.name.startsWith(prefix)) continue;
 
-				// if already exists in $stubs, bail
-				if ($stubs.find((s) => s.name === stub.name)) continue;
+				// if already exists in $files, bail
+				if ($files.find((f) => f.name === file.name)) continue;
 
 				// if intermediate directory exists, bail
-				if (child_prefixes.some((prefix) => stub.name.startsWith(prefix))) continue;
+				if (child_prefixes.some((prefix) => file.name.startsWith(prefix))) continue;
 
-				can_create[stub.type] = true;
+				can_create[file.type] = true;
 			}
 		}
 	}
@@ -148,7 +148,7 @@
 	{/if}
 
 	{#each child_directories as directory}
-		<svelte:self {directory} prefix={directory.name + '/'} depth={depth + 1} files={children} />
+		<svelte:self {directory} prefix={directory.name + '/'} depth={depth + 1} contents={children} />
 	{/each}
 
 	{#if mode === 'add_file'}

--- a/src/routes/tutorial/[slug]/filetree/Folder.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Folder.svelte
@@ -110,12 +110,12 @@
 <Item
 	{depth}
 	basename={directory.basename}
-	icon={$state.expanded[directory.name] ? folder_open : folder_closed}
+	icon={$state.collapsed[directory.name] ? folder_closed : folder_open}
 	can_rename={can_remove}
 	renaming={mode === 'renaming'}
 	{actions}
 	on:click={() => {
-		state.toggle_expanded(directory.name);
+		state.toggle_collapsed(directory.name);
 	}}
 	on:edit={() => {
 		mode = 'renaming';
@@ -128,12 +128,12 @@
 	}}
 	on:keydown={(e) => {
 		if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-			state.toggle_expanded(directory.name, e.key === 'ArrowRight');
+			state.toggle_collapsed(directory.name, e.key === 'ArrowLeft');
 		}
 	}}
 />
 
-{#if $state.expanded[directory.name]}
+{#if !$state.collapsed[directory.name]}
 	{#if mode === 'add_directory'}
 		<Item
 			depth={depth + 1}

--- a/src/routes/tutorial/[slug]/filetree/Folder.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Folder.svelte
@@ -22,7 +22,7 @@
 	/** @type {'idle' | 'add_file' | 'add_directory' | 'renaming'} */
 	let mode = 'idle';
 
-	const { rename, add, remove, readonly } = context.get();
+	const { collapsed, rename, add, remove, readonly } = context.get();
 
 	$: segments = get_depth(prefix);
 
@@ -110,12 +110,12 @@
 <Item
 	{depth}
 	basename={directory.basename}
-	icon={$state.collapsed[directory.name] ? folder_closed : folder_open}
+	icon={$collapsed[directory.name] ? folder_closed : folder_open}
 	can_rename={can_remove}
 	renaming={mode === 'renaming'}
 	{actions}
 	on:click={() => {
-		state.toggle_collapsed(directory.name);
+		$collapsed[directory.name] = !$collapsed[directory.name];
 	}}
 	on:edit={() => {
 		mode = 'renaming';
@@ -128,12 +128,12 @@
 	}}
 	on:keydown={(e) => {
 		if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-			state.toggle_collapsed(directory.name, e.key === 'ArrowLeft');
+			$collapsed[directory.name] = e.key === 'ArrowLeft';
 		}
 	}}
 />
 
-{#if !$state.collapsed[directory.name]}
+{#if !$collapsed[directory.name]}
 	{#if mode === 'add_directory'}
 		<Item
 			depth={depth + 1}

--- a/src/routes/tutorial/[slug]/filetree/context.js
+++ b/src/routes/tutorial/[slug]/filetree/context.js
@@ -3,7 +3,7 @@ import { setContext, getContext } from 'svelte';
 /**
  * @typedef {{
  *   readonly: import('svelte/store').Writable<boolean>;
- *   collapsed: import('svelte/store').Writable<Record<string, boolean>;
+ *   collapsed: import('svelte/store').Writable<Record<string, boolean>>;
  *   add: (name: string, type: 'file' | 'directory') => Promise<void>;
  *   rename: (stub: import('$lib/types').Stub, name: string) => Promise<void>;
  *   remove: (stub: import('$lib/types').Stub) => Promise<void>;

--- a/src/routes/tutorial/[slug]/filetree/context.js
+++ b/src/routes/tutorial/[slug]/filetree/context.js
@@ -3,6 +3,7 @@ import { setContext, getContext } from 'svelte';
 /**
  * @typedef {{
  *   readonly: import('svelte/store').Writable<boolean>;
+ *   collapsed: import('svelte/store').Writable<Record<string, boolean>;
  *   add: (name: string, type: 'file' | 'directory') => Promise<void>;
  *   rename: (stub: import('$lib/types').Stub, name: string) => Promise<void>;
  *   remove: (stub: import('$lib/types').Stub) => Promise<void>;

--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -11,7 +11,6 @@ import * as adapter from './adapter.js';
  *    editing_constraints: import("$lib/types").EditingConstraints;
  *    scope: import('$lib/types').Scope;
  *  };
- *  collapsed: Record<string, boolean>;
  * }} State
  */
 
@@ -30,7 +29,6 @@ const { subscribe, set, update } = writable({
 		},
 		scope: { name: '', prefix: '' }
 	},
-	collapsed: {}
 });
 
 export const state = {
@@ -64,17 +62,6 @@ export const state = {
 			create: exercise.editing_constraints.create,
 			remove: exercise.editing_constraints.remove
 		};
-
-		/** @type {Record<string, boolean>} */
-		const collapsed = {
-			'': false
-		};
-
-		for (const stub of Object.values(exercise.a)) {
-			if (stub.type === 'directory') {
-				collapsed[stub.name] = false;
-			}
-		}
 
 		// TODO should exercise.a/b be an array in the first place?
 		for (const stub of Object.values(exercise.b)) {
@@ -114,25 +101,10 @@ export const state = {
 				editing_constraints,
 				scope: exercise.scope
 			},
-			selected: exercise.focus,
-			collapsed
+			selected: exercise.focus
 		});
 
 		adapter.reset(stubs);
-	},
-
-	/**
-	 * @param {string} name
-	 * @param {boolean} [collapsed]
-	 */
-	toggle_collapsed: (name, collapsed) => {
-		update((state) => ({
-			...state,
-			collapsed: {
-				...state.collapsed,
-				[name]: collapsed ?? !state.collapsed[name]
-			}
-		}));
 	},
 
 	/** @param {string | null} name */

--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -11,48 +11,39 @@ export const solution = writable({});
 export const selected_name = writable(null);
 
 export const selected_file = derived([files, selected_name], ([$files, $selected_name]) => {
-	return /** @type{import('$lib/types').FileStub | undefined} */ (
-		$files.find((stub) => stub.name === $selected_name)
+	return (
+		/** @type{import('$lib/types').FileStub | undefined} */ (
+			$files.find((stub) => stub.name === $selected_name)
 		) ?? null
-})
+	);
+});
 
-export const state = {
-	/** @param {import('$lib/types').FileStub} file */
-	update_file: (file) => {
-		files.update($files => {
-			return $files.map((old) => {
-				if (old.name === file.name) {
-					return file;
-				}
-				return old;
-			})
+/** @param {import('$lib/types').FileStub} file */
+export function update_file(file) {
+	files.update(($files) => {
+		return $files.map((old) => {
+			if (old.name === file.name) {
+				return file;
+			}
+			return old;
 		});
+	});
 
-		adapter.update(file);
-	},
+	adapter.update(file);
+}
 
-	/** @param {import('$lib/types').Stub[]} stubs */
-	set_stubs: (stubs) => {
-		files.set(stubs);
-		adapter.reset(stubs);
-	},
+/** @param {import('$lib/types').Stub[]} stubs */
+export function set_stubs(stubs) {
+	files.set(stubs);
+	adapter.reset(stubs);
+}
 
-	/** @param {import('$lib/types').Exercise} exercise */
-	switch_exercise: (exercise) => {
-		const stubs = Object.values(exercise.a);
+/** @param {string | null} name */
+export function select_file(name) {
+	selected_name.set(name);
+}
 
-		files.set(stubs);
-
-		selected_name.set(exercise.focus);
-
-		adapter.reset(stubs);
-	},
-
-	/** @param {string | null} name */
-	select_file: (name) => {
-		selected_name.set(name);
-	}
-};
+export const state = {};
 
 // TODO get rid
 export const stubs = files;

--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -1,4 +1,5 @@
 import { derived, writable } from 'svelte/store';
+import * as adapter from './adapter.js';
 
 /**
  * @typedef {{
@@ -51,9 +52,11 @@ export const state = {
 			}),
 			last_updated: file
 		}));
+
+		adapter.update([file]);
 	},
 
-	/** @param {import('$lib/types').Stub[]} [stubs] */
+	/** @param {import('$lib/types').Stub[]} stubs */
 	set_stubs: (stubs) => {
 		update((state) => ({
 			...state,
@@ -61,6 +64,8 @@ export const state = {
 			stubs: stubs ?? state.stubs,
 			last_updated: undefined
 		}));
+
+		adapter.reset(stubs);
 	},
 
 	/** @param {import('$lib/types').Exercise} exercise */
@@ -110,11 +115,13 @@ export const state = {
 			}
 		}
 
+		const stubs = Object.values(exercise.a)
+
 		set({
 			status: 'switch',
-			stubs: Object.values(exercise.a),
+			stubs,
 			exercise: {
-				initial: Object.values(exercise.a),
+				initial: [...stubs],
 				solution,
 				editing_constraints,
 				scope: exercise.scope
@@ -123,6 +130,8 @@ export const state = {
 			selected: exercise.focus,
 			expanded
 		});
+
+		adapter.reset(stubs);
 	},
 
 	toggle_completion: () => {

--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -11,7 +11,7 @@ import * as adapter from './adapter.js';
  *    editing_constraints: import("$lib/types").EditingConstraints;
  *    scope: import('$lib/types').Scope;
  *  };
- *  expanded: Record<string, boolean>;
+ *  collapsed: Record<string, boolean>;
  * }} State
  */
 
@@ -30,7 +30,7 @@ const { subscribe, set, update } = writable({
 		},
 		scope: { name: '', prefix: '' }
 	},
-	expanded: {}
+	collapsed: {}
 });
 
 export const state = {
@@ -66,13 +66,13 @@ export const state = {
 		};
 
 		/** @type {Record<string, boolean>} */
-		const expanded = {
-			'': true
+		const collapsed = {
+			'': false
 		};
 
 		for (const stub of Object.values(exercise.a)) {
 			if (stub.type === 'directory') {
-				expanded[stub.name] = true;
+				collapsed[stub.name] = false;
 			}
 		}
 
@@ -115,29 +115,36 @@ export const state = {
 				scope: exercise.scope
 			},
 			selected: exercise.focus,
-			expanded
+			collapsed
 		});
 
 		adapter.reset(stubs);
 	},
 
 	toggle_completion: () => {
-		update((state) => ({
-			...state,
-			stubs: is_completed(state) ? state.exercise.initial : Object.values(state.exercise.solution),
-		}));
+		update((state) => {
+			const stubs = is_completed(state) ? state.exercise.initial : Object.values(state.exercise.solution);
+
+			// TODO bit naughty, putting this side-effect here
+			adapter.reset(stubs);
+
+			return {
+				...state,
+				stubs,
+			};
+		});
 	},
 
 	/**
 	 * @param {string} name
-	 * @param {boolean} [expanded]
+	 * @param {boolean} [collapsed]
 	 */
-	toggle_expanded: (name, expanded) => {
+	toggle_collapsed: (name, collapsed) => {
 		update((state) => ({
 			...state,
-			expanded: {
-				...state.expanded,
-				[name]: expanded ?? !state.expanded[name]
+			collapsed: {
+				...state.collapsed,
+				[name]: collapsed ?? !state.collapsed[name]
 			}
 		}));
 	},

--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -9,7 +9,6 @@ import * as adapter from './adapter.js';
  *    initial: import("$lib/types").Stub[];
  *    solution: Record<string, import("$lib/types").Stub>;
  *    editing_constraints: import("$lib/types").EditingConstraints;
- *    scope: import('$lib/types').Scope;
  *  };
  * }} State
  */
@@ -26,8 +25,7 @@ const { subscribe, set, update } = writable({
 		editing_constraints: {
 			create: [],
 			remove: []
-		},
-		scope: { name: '', prefix: '' }
+		}
 	},
 });
 
@@ -98,8 +96,7 @@ export const state = {
 			exercise: {
 				initial: [...stubs],
 				solution,
-				editing_constraints,
-				scope: exercise.scope
+				editing_constraints
 			},
 			selected: exercise.focus
 		});
@@ -129,8 +126,6 @@ export const selected = derived(
 export const solution = derived(state, ($state) => $state.exercise.solution);
 
 export const editing_constraints = derived(state, ($state) => $state.exercise.editing_constraints);
-
-export const scope = derived(state, ($state) => $state.exercise.scope);
 
 export const completed = derived(state, is_completed);
 

--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -48,7 +48,7 @@ export const state = {
 			}),
 		}));
 
-		adapter.update([file]);
+		adapter.update(file);
 	},
 
 	/** @param {import('$lib/types').Stub[]} stubs */

--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -6,9 +6,7 @@ import * as adapter from './adapter.js';
  *  stubs: import("$lib/types").Stub[];
  *  selected: string | null;
  *  exercise: {
- *    initial: import("$lib/types").Stub[];
  *    solution: Record<string, import("$lib/types").Stub>;
- *    editing_constraints: import("$lib/types").EditingConstraints;
  *  };
  * }} State
  */
@@ -20,12 +18,7 @@ const { subscribe, set, update } = writable({
 	stubs: [],
 	selected: null,
 	exercise: {
-		initial: [],
-		solution: {},
-		editing_constraints: {
-			create: new Set(),
-			remove: new Set()
-		}
+		solution: {}
 	},
 });
 
@@ -58,9 +51,7 @@ export const state = {
 		set({
 			stubs: exercise.initial,
 			exercise: {
-				initial: exercise.initial,
 				solution: exercise.solution,
-				editing_constraints: exercise.editing_constraints
 			},
 			selected: exercise.focus
 		});
@@ -88,8 +79,6 @@ export const selected = derived(
 );
 
 export const solution = derived(state, ($state) => $state.exercise.solution);
-
-export const editing_constraints = derived(state, ($state) => $state.exercise.editing_constraints);
 
 export const completed = derived(state, is_completed);
 

--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -3,9 +3,7 @@ import * as adapter from './adapter.js';
 
 /**
  * @typedef {{
- *  status: 'initial' | 'select' | 'set' | 'update' | 'switch' | 'expand';
  *  stubs: import("$lib/types").Stub[];
- *  last_updated?: import("$lib/types").FileStub;
  *  selected: string | null;
  *  exercise: {
  *    initial: import("$lib/types").Stub[];
@@ -21,7 +19,6 @@ import * as adapter from './adapter.js';
  * @type {import('svelte/store').Writable<State>}
  */
 const { subscribe, set, update } = writable({
-	status: 'initial',
 	stubs: [],
 	selected: null,
 	exercise: {
@@ -43,14 +40,12 @@ export const state = {
 	update_file: (file) => {
 		update((state) => ({
 			...state,
-			status: 'update',
 			stubs: state.stubs.map((stub) => {
 				if (stub.name === file.name) {
 					return file;
 				}
 				return stub;
 			}),
-			last_updated: file
 		}));
 
 		adapter.update([file]);
@@ -60,9 +55,7 @@ export const state = {
 	set_stubs: (stubs) => {
 		update((state) => ({
 			...state,
-			status: 'set',
-			stubs: stubs ?? state.stubs,
-			last_updated: undefined
+			stubs
 		}));
 
 		adapter.reset(stubs);
@@ -118,7 +111,6 @@ export const state = {
 		const stubs = Object.values(exercise.a)
 
 		set({
-			status: 'switch',
 			stubs,
 			exercise: {
 				initial: [...stubs],
@@ -126,7 +118,6 @@ export const state = {
 				editing_constraints,
 				scope: exercise.scope
 			},
-			last_updated: undefined,
 			selected: exercise.focus,
 			expanded
 		});
@@ -137,9 +128,7 @@ export const state = {
 	toggle_completion: () => {
 		update((state) => ({
 			...state,
-			status: 'set',
 			stubs: is_completed(state) ? state.exercise.initial : Object.values(state.exercise.solution),
-			last_updated: undefined
 		}));
 	},
 
@@ -150,7 +139,6 @@ export const state = {
 	toggle_expanded: (name, expanded) => {
 		update((state) => ({
 			...state,
-			status: 'expand',
 			expanded: {
 				...state.expanded,
 				[name]: expanded ?? !state.expanded[name]
@@ -162,9 +150,7 @@ export const state = {
 	select_file: (name) => {
 		update((state) => ({
 			...state,
-			status: 'select',
 			selected: name,
-			last_updated: undefined
 		}));
 	}
 };

--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -55,49 +55,17 @@ export const state = {
 
 	/** @param {import('$lib/types').Exercise} exercise */
 	switch_exercise: (exercise) => {
-		const solution = { ...exercise.a };
-		const editing_constraints = {
-			create: exercise.editing_constraints.create,
-			remove: exercise.editing_constraints.remove
-		};
-
-		// TODO should exercise.a/b be an array in the first place?
-		for (const stub of Object.values(exercise.b)) {
-			if (stub.type === 'file' && stub.contents.startsWith('__delete')) {
-				// remove file
-				editing_constraints.remove.add(stub.name);
-				delete solution[stub.name];
-			} else if (stub.name.endsWith('/__delete')) {
-				// remove directory
-				const parent = stub.name.slice(0, stub.name.lastIndexOf('/'));
-				editing_constraints.remove.add(parent);
-				delete solution[parent];
-				for (const k in solution) {
-					if (k.startsWith(parent + '/')) {
-						delete solution[k];
-					}
-				}
-			} else {
-				if (!solution[stub.name]) {
-					editing_constraints.create.add(stub.name);
-				}
-				solution[stub.name] = exercise.b[stub.name];
-			}
-		}
-
-		const stubs = Object.values(exercise.a)
-
 		set({
-			stubs,
+			stubs: exercise.initial,
 			exercise: {
-				initial: [...stubs],
-				solution,
-				editing_constraints
+				initial: exercise.initial,
+				solution: exercise.solution,
+				editing_constraints: exercise.editing_constraints
 			},
 			selected: exercise.focus
 		});
 
-		adapter.reset(stubs);
+		adapter.reset(exercise.initial);
 	},
 
 	/** @param {string | null} name */

--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -23,8 +23,8 @@ const { subscribe, set, update } = writable({
 		initial: [],
 		solution: {},
 		editing_constraints: {
-			create: [],
-			remove: []
+			create: new Set(),
+			remove: new Set()
 		}
 	},
 });
@@ -65,16 +65,12 @@ export const state = {
 		for (const stub of Object.values(exercise.b)) {
 			if (stub.type === 'file' && stub.contents.startsWith('__delete')) {
 				// remove file
-				if (!editing_constraints.remove.includes(stub.name)) {
-					editing_constraints.remove.push(stub.name);
-				}
+				editing_constraints.remove.add(stub.name);
 				delete solution[stub.name];
 			} else if (stub.name.endsWith('/__delete')) {
 				// remove directory
 				const parent = stub.name.slice(0, stub.name.lastIndexOf('/'));
-				if (!editing_constraints.remove.includes(parent)) {
-					editing_constraints.remove.push(parent);
-				}
+				editing_constraints.remove.add(parent);
 				delete solution[parent];
 				for (const k in solution) {
 					if (k.startsWith(parent + '/')) {
@@ -82,8 +78,8 @@ export const state = {
 					}
 				}
 			} else {
-				if (!solution[stub.name] && !editing_constraints.create.includes(stub.name)) {
-					editing_constraints.create.push(stub.name);
+				if (!solution[stub.name]) {
+					editing_constraints.create.add(stub.name);
 				}
 				solution[stub.name] = exercise.b[stub.name];
 			}

--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -32,18 +32,13 @@ export function update_file(file) {
 	adapter.update(file);
 }
 
-/** @param {import('$lib/types').Stub[]} stubs */
-export function set_stubs(stubs) {
-	files.set(stubs);
-	adapter.reset(stubs);
+/** @param {import('$lib/types').Stub[]} new_files */
+export function reset_files(new_files) {
+	files.set(new_files);
+	adapter.reset(new_files);
 }
 
 /** @param {string | null} name */
 export function select_file(name) {
 	selected_name.set(name);
 }
-
-export const state = {};
-
-// TODO get rid
-export const stubs = files;

--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -121,20 +121,6 @@ export const state = {
 		adapter.reset(stubs);
 	},
 
-	toggle_completion: () => {
-		update((state) => {
-			const stubs = is_completed(state) ? state.exercise.initial : Object.values(state.exercise.solution);
-
-			// TODO bit naughty, putting this side-effect here
-			adapter.reset(stubs);
-
-			return {
-				...state,
-				stubs,
-			};
-		});
-	},
-
 	/**
 	 * @param {string} name
 	 * @param {boolean} [collapsed]

--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -53,11 +53,7 @@ export const state = {
 
 	/** @param {import('$lib/types').Stub[]} stubs */
 	set_stubs: (stubs) => {
-		update((state) => ({
-			...state,
-			stubs
-		}));
-
+		update((state) => ({ ...state, stubs }));
 		adapter.reset(stubs);
 	},
 


### PR DESCRIPTION
This simplifies the adapter code per #248. There was a bit too much indirection previously (also we were conflating state and events, which I think is a bit of a code smell) and I found it quite hard to make changes — there's still room for improvement but I'm much happier with this. 

There are a couple of glitches to work through still:

* [ ] rapidly navigating between e.g. [/tutorial/universal-load-functions](https://learn-svelte-dev-git-gh-248-svelte.vercel.app/tutorial/universal-load-functions) and [/tutorial/the-form-element](https://learn-svelte-dev-git-gh-248-svelte.vercel.app/tutorial/the-form-element) will result in a fallback error page, which sometimes doesn't self-repair
* [x] if you navigate to a path like `/about` on [/tutorial/pages](https://learn-svelte-dev-git-gh-248-svelte.vercel.app/tutorial/pages), that path will persist when you navigate to other exercises