### PR TITLE
fix: codemirror scroll behaviour

### DIFF
--- a/src/routes/tutorial/[slug]/Editor.svelte
+++ b/src/routes/tutorial/[slug]/Editor.svelte
@@ -51,8 +51,9 @@
 
 	$: reset($files);
 
+	$: select_state($selected_name);
+
 	$: if (editor_view) {
-		select_state($selected_name);
 
 		if ($selected_name) {
 			const current_warnings = $warnings[$selected_name];

--- a/src/routes/tutorial/[slug]/Editor.svelte
+++ b/src/routes/tutorial/[slug]/Editor.svelte
@@ -137,7 +137,9 @@
 				extensions: [EditorState.readOnly.of(true)]
 			});
 
-		editor_view.setState(state);
+		if (state !== editor_view.state) {
+			editor_view.setState(state);
+		}
 	}
 
 	onMount(() => {
@@ -146,20 +148,23 @@
 			async dispatch(transaction) {
 				editor_view.update([transaction]);
 
-				if (transaction.docChanged && $selected_file) {
-					skip_reset = true;
-
-					// TODO do we even need to update `$files`? maintaining separate editor states is probably sufficient
-					update_file({
-						...$selected_file,
-						contents: editor_view.state.doc.toString()
-					});
+				if ($selected_file) {
 
 					// keep `editor_states` updated so that undo/redo history is preserved for files independently
 					editor_states.set($selected_file.name, editor_view.state);
 
-					await tick();
-					skip_reset = false;
+					if (transaction.docChanged) {
+						skip_reset = true;
+
+						// TODO do we even need to update `$files`? maintaining separate editor states is probably sufficient
+						update_file({
+							...$selected_file,
+							contents: editor_view.state.doc.toString()
+						});
+
+						await tick();
+						skip_reset = false;
+					}
 				}
 			}
 		});

--- a/src/routes/tutorial/[slug]/Editor.svelte
+++ b/src/routes/tutorial/[slug]/Editor.svelte
@@ -137,9 +137,7 @@
 				extensions: [EditorState.readOnly.of(true)]
 			});
 
-		if (state !== editor_view.state) {
-			editor_view.setState(state);
-		}
+		editor_view.setState(state);
 	}
 
 	onMount(() => {
@@ -148,23 +146,20 @@
 			async dispatch(transaction) {
 				editor_view.update([transaction]);
 
-				if ($selected_file) {
+				if (transaction.docChanged && $selected_file) {
+					skip_reset = true;
+
+					// TODO do we even need to update `$files`? maintaining separate editor states is probably sufficient
+					update_file({
+						...$selected_file,
+						contents: editor_view.state.doc.toString()
+					});
 
 					// keep `editor_states` updated so that undo/redo history is preserved for files independently
 					editor_states.set($selected_file.name, editor_view.state);
 
-					if (transaction.docChanged) {
-						skip_reset = true;
-
-						// TODO do we even need to update `$files`? maintaining separate editor states is probably sufficient
-						update_file({
-							...$selected_file,
-							contents: editor_view.state.doc.toString()
-						});
-
-						await tick();
-						skip_reset = false;
-					}
+					await tick();
+					skip_reset = false;
 				}
 			}
 		});


### PR DESCRIPTION
Fixes #299 

According to the codemirror documentation, [`setState`](https://codemirror.net/docs/ref/#view.EditorView.setState) reset the view, and may causes some side effects .

Currently `setState` is called every time the code is changed (not just when switching files). It can be fixed by calling it only when switching files
