### PR TITLE
fix: prevent content from being reset

### DIFF
--- a/content/tutorial/common/src/__client.js
+++ b/content/tutorial/common/src/__client.js
@@ -1,19 +1,3 @@
-// Hack into the alert that's used in some tutorials and send a message prior to the alert,
-// else the parent thinks we lost contact and wrongfully reloads the page.
-// The drawback is that alert is no longer blocking, but no tutorial relies on this.
-const alert = window.alert;
-window.alert = (message) => {
-	parent.postMessage(
-		{
-			type: 'ping-pause'
-		},
-		'*'
-	);
-	setTimeout(() => {
-		alert(message);
-	});
-};
-
 window.addEventListener('message', async (e) => {
 	if (e.data.type === 'fetch') {
 		const names = e.data.names;
@@ -121,7 +105,6 @@ function ping() {
 	);
 }
 
-setInterval(ping, 100);
 ping();
 
 if (import.meta.hot) {

--- a/src/routes/tutorial/[slug]/Output.svelte
+++ b/src/routes/tutorial/[slug]/Output.svelte
@@ -34,13 +34,6 @@
 		};
 	});
 
-	afterNavigate(() => {
-		clearTimeout(timeout);
-	});
-
-	/** @type {any} */
-	let timeout;
-
 	/** @param {MessageEvent} e */
 	async function handle_message(e) {
 		if (e.origin !== $base) return;
@@ -48,20 +41,7 @@
 		if (paused) return;
 
 		if (e.data.type === 'ping') {
-			path = e.data.data.path ?? path;
 			loading = false;
-
-			clearTimeout(timeout);
-			timeout = setTimeout(() => {
-				if (dev && !iframe) return;
-
-				// we lost contact, refresh the page
-				loading = true;
-				set_iframe_src($base + path);
-				loading = false;
-			}, 1000);
-		} else if (e.data.type === 'ping-pause') {
-			clearTimeout(timeout);
 		} else if (e.data.type === 'warnings') {
 			warnings.update(($warnings) => ({
 				...$warnings,


### PR DESCRIPTION
ref: https://github.com/sveltejs/learn.svelte.dev/pull/302#issuecomment-1486584294 , https://github.com/sveltejs/learn.svelte.dev/pull/303#issue-1643639716

Fixes #298 

SvelteKit's version has been updated to 1.14 (now 1.15), which improves recovery from errors. Now, code such as `ping` and `timeout` (the cause of #298, see [here](https://github.com/sveltejs/learn.svelte.dev/issues/298#issuecomment-1482954163)) should no longer be needed.