### PR TITLE
fix: prevent build failure due to cache files

### DIFF
--- a/scripts/create-common-bundle/index.js
+++ b/scripts/create-common-bundle/index.js
@@ -5,6 +5,10 @@ import glob from 'tiny-glob/sync.js';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 
+if (!!process.env.VERCEL) {
+	execSync('git clean -d -f content/tutorial');
+}
+
 const cwd = 'content/tutorial/common';
 
 execSync('npm ci', { cwd });

--- a/src/lib/server/content.js
+++ b/src/lib/server/content.js
@@ -30,6 +30,15 @@ function is_valid(dir) {
 }
 
 /**
+ * @param {string} part
+ * @param {string} chapter
+ * @param {string} dir
+ */
+function exists_readme(part, chapter, dir) {
+	return fs.existsSync(`content/tutorial/${part}/${chapter}/${dir}/README.md`);
+}
+
+/**
  * @returns {import('$lib/types').PartStub[]}
  */
 export function get_index() {
@@ -44,7 +53,7 @@ export function get_index() {
 			chapters: chapters.map((chapter) => {
 				const exercises = fs
 					.readdirSync(`content/tutorial/${part}/${chapter}`)
-					.filter(is_valid)
+					.filter((dir) => is_valid(dir) && exists_readme(part, chapter, dir))
 					.map(posixify);
 
 				return {


### PR DESCRIPTION
The following are logs of a build failed in Vercel (these are from folk site for Japanese, but probably the same error occurs in learn.svelte.dev).

```log
23:29:08.034 | Error: ENOENT: no such file or directory, open 'content/tutorial/01-svelte/06-bindings/05-textarea-inputs/README.md'
23:29:08.034 | at Object.openSync (node:fs:600:3)
23:29:08.034 | at Object.readFileSync (node:fs:468:35)
...
```

This is due to old files still in Vercel.

