### PR TITLE
Fix user comment bug

### DIFF
--- a/content/tutorial/01-svelte/07-lifecycle/02-update/app-a/src/lib/App.svelte
+++ b/content/tutorial/01-svelte/07-lifecycle/02-update/app-a/src/lib/App.svelte
@@ -27,8 +27,6 @@
 
 	async function handleKeydown(event) {
 		if (event.key === 'Enter' && event.target.value) {
-			event.target.value = '';
-
 			const comment = {
 				author: 'user',
 				text: event.target.value
@@ -39,6 +37,7 @@
 				text: eliza.transform(comment.text)
 			};
 
+			event.target.value = '';
 			comments = [...comments, comment];
 
 			await pause(200 * (1 + Math.random()));


### PR DESCRIPTION
User comments appear as empty chat bubbles because we clear the input value _before_ recording the comment string. This fixes that.