### PR TITLE
fix: accept autocompletions with Tab key without losing focus

### DIFF
--- a/src/routes/tutorial/[slug]/Editor.svelte
+++ b/src/routes/tutorial/[slug]/Editor.svelte
@@ -206,15 +206,6 @@
 <div
 	class="container"
 	bind:this={container}
-	on:keydown={(e) => {
-		if (e.key === 'Tab') {
-			preserve_editor_focus = false;
-
-			setTimeout(() => {
-				preserve_editor_focus = true;
-			}, 200);
-		}
-	}}
 	on:focusin={() => {
 		clearTimeout(remove_focus_timeout);
 		preserve_editor_focus = true;


### PR DESCRIPTION
Fixes #324 

The code removed in this PR worked in combination with the processing that was previously in `on:focusout`.
It should no longer be needed now.

As a side note, while I was testing this PR, I learned that Monaco and Codemirror have different tab trapping keys.
https://codemirror.net/examples/tab/