### PR TITLE
Fix typo

### DIFF
--- a/content/tutorial/02-advanced-svelte/01-motion/01-tweens/README.md
+++ b/content/tutorial/02-advanced-svelte/01-motion/01-tweens/README.md
@@ -2,7 +2,7 @@
 title: Tweens
 ---
 
-Now that we've covered the basics of SvelteKit, it's time to learn some advanced Svelte techniques, starting with _motion_.
+Now that we've covered the basics of Svelte, it's time to learn some advanced Svelte techniques, starting with _motion_.
 
 Setting values and watching the DOM update automatically is cool. Know what's even cooler? Tweening those values. Svelte includes tools to help you build slick user interfaces that use animation to communicate changes.
 

--- a/content/tutorial/02-advanced-svelte/01-motion/01-tweens/README.md
+++ b/content/tutorial/02-advanced-svelte/01-motion/01-tweens/README.md
@@ -2,7 +2,7 @@
 title: Tweens
 ---
 
-Now that we've covered the basics of Svelte, it's time to learn some advanced Svelte techniques, starting with _motion_.
+Now that we've covered the basics, it's time to learn some advanced Svelte techniques, starting with _motion_.
 
 Setting values and watching the DOM update automatically is cool. Know what's even cooler? Tweening those values. Svelte includes tools to help you build slick user interfaces that use animation to communicate changes.
 


### PR DESCRIPTION
Fixed typo in the start of part two of svelte tutorial where it says you've finished the basics of sveltekit.