### PR TITLE
Remove extraneous call to loop function

### DIFF
--- a/content/tutorial/01-svelte/07-lifecycle/01-onmount/README.md
+++ b/content/tutorial/01-svelte/07-lifecycle/01-onmount/README.md
@@ -49,8 +49,6 @@ onMount(() => {
 		paint(context, t);
 	});
 
-	loop();
-
 +++	return () => {
 		cancelAnimationFrame(frame);
 	};+++


### PR DESCRIPTION
This extra call to the `loop` function isn't present in `app-b/src/lib/App.svelte`, so it should be removed from the text of the tutorial.

I made this commit and PR completely through GitHub, so that's too blame for the change on the last line. I don't know if there's a "newline at EOF" policy for this repository.