### PR TITLE
Separate path pings from normal pings

### DIFF
--- a/content/tutorial/common/src/__client.js
+++ b/content/tutorial/common/src/__client.js
@@ -2,11 +2,8 @@ function post(data) {
 	parent.postMessage(data, '*');
 }
 
-function ping() {
-	post({
-		type: 'ping',
-		path: location.pathname + location.search + location.hash
-	});
+function ping(path = location.pathname + location.search + location.hash) {
+	post({ type: 'ping', path });
 }
 
 function pause() {
@@ -58,6 +55,8 @@ window.addEventListener('click', (e) => {
 			if (url.origin !== location.origin) {
 				e.preventDefault();
 				window.open(url, '_blank');
+			} else {
+				ping(url.pathname + url.search + url.hash);
 			}
 		}
 		node = node.parent;

--- a/content/tutorial/common/src/__client.js
+++ b/content/tutorial/common/src/__client.js
@@ -2,8 +2,12 @@ function post(data) {
 	parent.postMessage(data, '*');
 }
 
-function ping(path = location.pathname + location.search + location.hash) {
-	post({ type: 'ping', path });
+function update_path(path) {
+	post({ type: 'path', path });
+}
+
+function ping() {
+	post({ type: 'ping' });
 }
 
 function pause() {
@@ -56,7 +60,7 @@ window.addEventListener('click', (e) => {
 				e.preventDefault();
 				window.open(url, '_blank');
 			} else {
-				ping(url.pathname + url.search + url.hash);
+				update_path(url.pathname + url.search + url.hash);
 			}
 		}
 		node = node.parent;
@@ -76,7 +80,7 @@ let previous_href = location.href;
 const url_observer = new MutationObserver(() => {
 	if (location.href !== previous_href) {
 		previous_href = location.href;
-		ping();
+		update_path(location.pathname + location.search + location.hash);
 	}
 });
 

--- a/src/routes/tutorial/[slug]/Chrome.svelte
+++ b/src/routes/tutorial/[slug]/Chrome.svelte
@@ -23,6 +23,12 @@
 		on:change={(e) => {
 			dispatch('change', { value: e.currentTarget.value });
 		}}
+		on:keydown={(e) => {
+			if (e.key === 'Enter') {
+				dispatch('change', { value: e.currentTarget.value });
+				e.currentTarget.blur();
+			}
+		}}
 	/>
 
 	<a {href} class="new-tab icon" target="_blank" aria-label="open in new tab" tabindex="0" />

--- a/src/routes/tutorial/[slug]/Output.svelte
+++ b/src/routes/tutorial/[slug]/Output.svelte
@@ -47,8 +47,9 @@
 
 		if (paused) return;
 
-		if (e.data.type === 'ping') {
+		if (e.data.type === 'path') {
 			path = e.data.path;
+		} else if (e.data.type === 'ping') {
 			loading = false;
 
 			clearTimeout(timeout);


### PR DESCRIPTION
This is #355 but with an additional fix. Eagerly updating the URL bar doesn't work great in exercises like https://learn-svelte-dev-git-fork-tomoam-fix-348-svelte.vercel.app/tutorial/preload, because the browser doesn't update the URL bar until the navigation is committed. This means that the URL bar changes briefly, then reverts, then changes again once the navigation finishes.

(Technically it's incorrect to eagerly update the URL for a slow navigation, but that only affects a very small number of exercises — maybe just one — so I think it's worth it.)