### PR TITLE
Remove alert about the page store

### DIFF
--- a/content/tutorial/03-sveltekit/09-errors-and-redirects/02-error-pages/README.md
+++ b/content/tutorial/03-sveltekit/09-errors-and-redirects/02-error-pages/README.md
@@ -19,8 +19,6 @@ The default error page is somewhat bland. We can customize it by creating a `src
 </span>
 ```
 
-> We're using the `page` store, which we'll learn more about in a later chapter.
-
 Notice that the `+error.svelte` component is rendered inside the root `+layout.svelte`. We can create more granular `+error.svelte` boundaries:
 
 ```svelte


### PR DESCRIPTION
Already covered in a previous chapter https://learn.svelte.dev/tutorial/page-store

