### PR TITLE
docs(tutorial): add note on reactive statements

### DIFF
--- a/content/tutorial/01-svelte/02-reactivity/02-reactive-declarations/README.md
+++ b/content/tutorial/01-svelte/02-reactivity/02-reactive-declarations/README.md
@@ -24,3 +24,5 @@ Let's use `doubled` in our markup:
 ```
 
 Of course, you could just write `{count * 2}` in the markup instead — you don't have to use reactive values. Reactive values become particularly valuable (no pun intended) when you need to reference them multiple times, or you have values that depend on _other_ reactive values.
+
+> Note that reactive declarations and statements will run after other script code and before component markup is rendered.


### PR DESCRIPTION
Note to learner that reactive statements run after script code, to complement documentation at https://svelte.dev/docs#component-format-script-3-$-marks-a-statement-as-reactive