### PR TITLE
typo fix in [Part 1 / Logic / If blocks]

### DIFF
--- a/content/tutorial/01-svelte/04-logic/01-if-blocks/README.md
+++ b/content/tutorial/01-svelte/04-logic/01-if-blocks/README.md
@@ -18,4 +18,4 @@ To conditionally render some markup, we wrap it in an `if` block. Let's add some
 {/if}+++
 ```
 
-Try it — update the component, and click on the buttons.
+Try it — update the component, and click on the button.


### PR DESCRIPTION
Removed "s" from "buttons" as there is only one button.