### PR TITLE
Rename variables for clarity

### DIFF
--- a/content/tutorial/01-svelte/02-reactivity/04-updating-arrays-and-objects/app-a/src/lib/App.svelte
+++ b/content/tutorial/01-svelte/02-reactivity/04-updating-arrays-and-objects/app-a/src/lib/App.svelte
@@ -5,7 +5,7 @@
 		numbers.push(numbers.length + 1);
 	}
 
-	$: sum = numbers.reduce((t, n) => t + n, 0);
+	$: sum = numbers.reduce((total, currentNumber) => total + currentNumber, 0);
 </script>
 
 <p>{numbers.join(' + ')} = {sum}</p>

--- a/content/tutorial/01-svelte/02-reactivity/04-updating-arrays-and-objects/app-b/src/lib/App.svelte
+++ b/content/tutorial/01-svelte/02-reactivity/04-updating-arrays-and-objects/app-b/src/lib/App.svelte
@@ -5,7 +5,7 @@
 		numbers = [...numbers, numbers.length + 1];
 	}
 
-	$: sum = numbers.reduce((t, n) => t + n, 0);
+	$: sum = numbers.reduce((total, currentNumber) => total + currentNumber, 0);
 </script>
 
 <p>{numbers.join(' + ')} = {sum}</p>


### PR DESCRIPTION
Variable names `t` and `n` would be confusing for beginners, hence changing it to `total` and `currentNumber`

