### PR TITLE
docs: Typo in Sharing Code tutorial

### DIFF
--- a/content/tutorial/02-advanced-svelte/10-module-context/01-sharing-code/README.md
+++ b/content/tutorial/02-advanced-svelte/10-module-context/01-sharing-code/README.md
@@ -4,7 +4,7 @@ title: Sharing code
 
 In all the examples we've seen so far, the `<script>` block contains code that runs when each component instance is initialised. For the vast majority of components, that's all you'll ever need.
 
-Very occasionally, you'll need to run some code outside of an individual component instance. For example: returning to our custom audio player from a [previous exercise](media-elements), you can play all five tracks simultaneously. It would be better if playing one stopped all the others.
+Very occasionally, you'll need to run some code outside of an individual component instance. For example: returning to our custom audio player from a [previous exercise](media-elements), you can play all four tracks simultaneously. It would be better if playing one stopped all the others.
 
 We can do that by declaring a `<script context="module">` block. Code contained inside it will run once, when the module first evaluates, rather than when a component is instantiated. Place this at the top of `AudioPlayer.svelte`:
 


### PR DESCRIPTION
Thanks for the wonderful tutorial, very much enjoying working through it and learning Svelte / SvelteKit!

This PR corrects a small typo in the sharing code tutorial, the text references five tracks, when there are in fact [four](https://github.com/tcbegley/learn.svelte.dev/blob/e05aafe4e7bfcb0e4a1f35ab511b9d0b01940929/content/tutorial/02-advanced-svelte/10-module-context/01-sharing-code/app-a/src/lib/tracks.js).

I guess it's kind of an off by one error? 😄 