### PR TITLE
Fixes an outdated link

### DIFF
--- a/content/tutorial/04-advanced-sveltekit/05-advanced-loading/01-universal-load-functions/README.md
+++ b/content/tutorial/04-advanced-sveltekit/05-advanced-loading/01-universal-load-functions/README.md
@@ -34,4 +34,4 @@ We can now use the `component` returned from these `load` functions like any oth
 </nav>
 ```
 
-Read the [documentation](https://kit.svelte.dev/docs/load#shared-vs-server) to learn more about the distinction between server `load` functions and universal `load` functions, and when to use which.
+Read the [documentation](https://kit.svelte.dev/docs/load#universal-vs-server) to learn more about the distinction between server `load` functions and universal `load` functions, and when to use which.


### PR DESCRIPTION
Hello!

I noticed that the link located at the bottom of [Universal Load Functions](https://learn.svelte.dev/tutorial/universal-load-functions) points to an outdated section of the documentation. It seems that at some point the title of the section changed making the link also change.