### PR TITLE
Add examples to @html tag warning

### DIFF
--- a/content/tutorial/01-svelte/01-introduction/06-html-tags/README.md
+++ b/content/tutorial/01-svelte/01-introduction/06-html-tags/README.md
@@ -13,4 +13,4 @@ In Svelte, you do this with the special `{@html ...}` tag:
 <p>{+++@html+++ string}</p>
 ```
 
-> **Warning!** Svelte doesn't perform any sanitization of the expression inside `{@html ...}` before it gets inserted into the DOM. In other words, if you use this feature it's critical that you manually escape HTML that comes from sources you don't trust, otherwise you risk exposing your users to <a href="https://owasp.org/www-community/attacks/xss/" target="_blank">Cross-Site Scripting</a> (XSS) attacks.
+> **Warning!** Svelte doesn't perform any sanitization of the expression inside `{@html ...}` before it gets inserted into the DOM. This isn't an issue if the content is something you trust like an article you wrote youself. However if it's some untrusted user content, e.g. a comment on an article, then it's critical that you manually escape it, otherwise you risk exposing your users to <a href="https://owasp.org/www-community/attacks/xss/" target="_blank">Cross-Site Scripting</a> (XSS) attacks.


### PR DESCRIPTION
Whenever I have people who a new to web development try the Svelte tutorial, they always freeze at the ominous warning on the @html tag, because they have to wonder "what is HTML that comes from sources I don't trust?".

So I updated the text so it now uses a self authored article as an example of trusted content, and a comment on an article as an example of untrusted content. Hopefully this is a bit more approachable to new developers.