### PR TITLE
docs: fix typos in @html tag lesson warning and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo uses [pnpm](https://pnpm.io/).
 
 ## Developing the app
 
-First, run `node scripts/create-common-bundle`. This packages up everything that's needed to run a SvelteKit app (Vite, Esbuild, SvelteKit, Svelte compiler etc) which can subsequently be unpacked on a server to create and run and instance of a SvelteKit application (which powers the output window of the tutorial). Then, run `dev`:
+First, run `node scripts/create-common-bundle`. This packages up everything that's needed to run a SvelteKit app (Vite, esbuild, SvelteKit, Svelte compiler, etc.) which can subsequently be unpacked on a server to create and run an instance of a SvelteKit application (which powers the output window of the tutorial). Then, run `dev`:
 
 ```bash
 node scripts/create-common-bundle

--- a/content/tutorial/01-svelte/01-introduction/06-html-tags/README.md
+++ b/content/tutorial/01-svelte/01-introduction/06-html-tags/README.md
@@ -13,4 +13,4 @@ In Svelte, you do this with the special `{@html ...}` tag:
 <p>{+++@html+++ string}</p>
 ```
 
-> **Warning!** Svelte doesn't perform any sanitization of the expression inside `{@html ...}` before it gets inserted into the DOM. This isn't an issue if the content is something you trust like an article you wrote youself. However if it's some untrusted user content, e.g. a comment on an article, then it's critical that you manually escape it, otherwise you risk exposing your users to <a href="https://owasp.org/www-community/attacks/xss/" target="_blank">Cross-Site Scripting</a> (XSS) attacks.
+> **Warning!** Svelte doesn't perform any sanitization of the expression inside `{@html ...}` before it gets inserted into the DOM. This isn't an issue if the content is something you trust like an article you wrote yourself. However if it's some untrusted user content, e.g. a comment on an article, then it's critical that you manually escape it, otherwise you risk exposing your users to <a href="https://owasp.org/www-community/attacks/xss/" target="_blank">Cross-Site Scripting</a> (XSS) attacks.


### PR DESCRIPTION
Just a tiny typo fix: `youself` -> `yourself`

Edit: I also found a small typo (`and` -> `an`) in the README after I created the PR and sneaked that inside of this PR, I hope that's okay. 😄 