### PR TITLE
Recognize that cookie value is a string

### DIFF
--- a/content/tutorial/03-sveltekit/04-headers-and-cookies/02-cookies/app-a/src/routes/+page.svelte
+++ b/content/tutorial/03-sveltekit/04-headers-and-cookies/02-cookies/app-a/src/routes/+page.svelte
@@ -2,4 +2,4 @@
 	export let data;
 </script>
 
-<h1>Hello {data.visited ? 'friend' : 'stranger'}!</h1>
+<h1>Hello {data.visited === "true" ? 'friend' : 'stranger'}!</h1>


### PR DESCRIPTION
The tutorial presently makes it seem like a cookie's value can be a non-string. This is one possible adjustment to the exercise code to avoid such confusion. Alternatively, +page.server.js could get ```visited```'s value by performing the same check.