### PR TITLE
Update README.md for page options

### DIFF
--- a/content/tutorial/04-advanced-sveltekit/02-page-options/01-page-options/README.md
+++ b/content/tutorial/04-advanced-sveltekit/02-page-options/01-page-options/README.md
@@ -2,7 +2,7 @@
 title: Basics
 ---
 
-In the chapter on [loading data](/tutorial/page-data), we saw how you can export `load` functions from `+page.server.js` and `+layout.server.js` files. These functions can also be exported from their client side rendering alternatives - '+page.js' and '+layout.js'. Additionally, we can also export various **page options** from these modules:
+In the chapter on [loading data](/tutorial/page-data), we saw how you can export `load` functions from `+page.server.js` and `+layout.server.js` files. As we will see later in the chapter on [universal load functions](/tutorial/universal-load-functions), these `load` functions can also be exported from `+page.js` and `+layout.js`. Additionally, we can also export various **page options** from these modules:
 
 - `ssr` — whether or not pages should be server-rendered
 - `csr` — whether to load the SvelteKit client

--- a/content/tutorial/04-advanced-sveltekit/02-page-options/01-page-options/README.md
+++ b/content/tutorial/04-advanced-sveltekit/02-page-options/01-page-options/README.md
@@ -2,7 +2,7 @@
 title: Basics
 ---
 
-In the chapter on [loading data](/tutorial/page-data), we saw how you can export `load` functions from `+page.js`, `+page.server.js`, `+layout.js` and `+layout.server.js` files. We can also export various **page options** from these modules:
+In the chapter on [loading data](/tutorial/page-data), we saw how you can export `load` functions from `+page.server.js` and `+layout.server.js` files. We can also export them from their client side alternatives - '+page.js' and '+layout.js'. We can also export various **page options** from these modules:
 
 - `ssr` — whether or not pages should be server-rendered
 - `csr` — whether to load the SvelteKit client

--- a/content/tutorial/04-advanced-sveltekit/02-page-options/01-page-options/README.md
+++ b/content/tutorial/04-advanced-sveltekit/02-page-options/01-page-options/README.md
@@ -2,7 +2,7 @@
 title: Basics
 ---
 
-In the chapter on [loading data](/tutorial/page-data), we saw how you can export `load` functions from `+page.server.js` and `+layout.server.js` files. We can also export them from their client side alternatives - '+page.js' and '+layout.js'. We can also export various **page options** from these modules:
+In the chapter on [loading data](/tutorial/page-data), we saw how you can export `load` functions from `+page.server.js` and `+layout.server.js` files. These functions can also be exported from their client side rendering alternatives - '+page.js' and '+layout.js'. Additionally, we can also export various **page options** from these modules:
 
 - `ssr` — whether or not pages should be server-rendered
 - `csr` — whether to load the SvelteKit client


### PR DESCRIPTION
Updated the readme for page options in SvelteKit advanced tutorial.

The file names +page.js and +layout.js are misleading as we do not encounter them in the tutorials upto this point. It is very easy to confuse them with +page.svelte. These files are only encountered at this point in the tutorial flow - https://learn.svelte.dev/tutorial/universal-load-functions. Hence, a differentiation would be good. 

Either we differentiate it as suggested in the PR or we update the [loading data](https://github.com/sveltejs/learn.svelte.dev/tree/main/content/tutorial/03-sveltekit/03-loading-data/01-page-data) reference. I would prefer the former as upto this point client side rendering is not talked about