### PR TITLE
Update README.md

### DIFF
--- a/content/tutorial/02-advanced-svelte/01-motion/01-tweens/README.md
+++ b/content/tutorial/02-advanced-svelte/01-motion/01-tweens/README.md
@@ -34,6 +34,8 @@ Clicking the buttons causes the progress bar to animate to its new value. It's a
 
 > The `svelte/easing` module contains the [Penner easing equations](https://web.archive.org/web/20190805215728/http://robertpenner.com/easing/), or you can supply your own `p => t` function where `p` and `t` are both values between 0 and 1.
 
+Note that the progress variable is still a store, but now it is a tweened store that enables smooth transitions and animations between values.
+
 The full set of options available to `tweened`:
 
 - `delay` — milliseconds before the tween starts


### PR DESCRIPTION
Since it was not specific, so it oponed the question if the pogress variable would keep being a store.

It might be useful to know which other elements in Svelte Motion have similar behaviour to a store, as I understand some of these elements use store internally so making use of them in a variable makes that variable a store(?).