### PR TITLE
docs: change grammar to help reduce confusion

### DIFF
--- a/content/tutorial/03-sveltekit/03-loading-data/02-layout-data/README.md
+++ b/content/tutorial/03-sveltekit/03-loading-data/02-layout-data/README.md
@@ -45,6 +45,6 @@ Now, add a sidebar in the layout for the post page:
 </style>
 ```
 
-The layout (and the page below it) inherits `data.summaries` from the parent `+layout.server.js`.
+The layout (and any page below it) inherits `data.summaries` from the parent `+layout.server.js`.
 
 When we navigate from one post to another, we only need to load the data for the post itself — the layout data is still valid. See the documentation on [invalidation](https://kit.svelte.dev/docs/load#rerunning-load-functions) to learn more.


### PR DESCRIPTION
It was not clear which page below the layout inherits the data, because in fact it could be any page.

The confusion can arise from the way the previous sentence was expressed, as **visually**, there is nothing `below` the layout in the project tree.

There are siblings though, like `+page.svelte` but for a Svelte beginner it is **not** immediately obvious that this page also falls `below` (or **under**) the same layout.