### PR TITLE
docs: make loading data link consistent with the chapter title

### DIFF
--- a/content/tutorial/03-sveltekit/06-forms/01-the-form-element/README.md
+++ b/content/tutorial/03-sveltekit/06-forms/01-the-form-element/README.md
@@ -2,7 +2,7 @@
 title: The <form> element
 ---
 
-In the [chapter on loading](page-data), we saw how to get data from the server to the browser. Sometimes you need to send data in the opposite direction, and that's where `<form>` — the web platform's way of submitting data — comes in.
+In the chapter on [loading data](page-data), we saw how to get data from the server to the browser. Sometimes you need to send data in the opposite direction, and that's where `<form>` — the web platform's way of submitting data — comes in.
 
 Let's build a todo app. We've already got an in-memory database set up in `src/lib/server/database.js`, and our `load` function in `src/routes/+page.server.js` uses the [`cookies`](https://kit.svelte.dev/docs/load#cookies-and-headers) API so that we can have a per-user todo list, but we need to add a `<form>` to create new todos:
 


### PR DESCRIPTION
Since the chapter is called `Loading data`, this changed link is consistent with it.