### PR TITLE
fix: make the background opaque

### DIFF
--- a/src/routes/tutorial/[slug]/filetree/ContextMenu.svelte
+++ b/src/routes/tutorial/[slug]/filetree/ContextMenu.svelte
@@ -55,7 +55,8 @@
 	ul {
 		margin: 0;
 		padding: 0;
-		background-color: var(--sk-theme-1);
+		background-color: var(--sk-back-3);
+		border: 1px solid hsl(var(--sk-theme-1-hsl));
 	}
 
 	li {

--- a/src/routes/tutorial/[slug]/filetree/ContextMenu.svelte
+++ b/src/routes/tutorial/[slug]/filetree/ContextMenu.svelte
@@ -55,12 +55,16 @@
 	ul {
 		margin: 0;
 		padding: 0;
+		background-color: var(--sk-theme-1);
 	}
 
 	li {
 		display: block;
 		list-style-type: none;
 		width: 1fr;
+	}
+	li:hover {
+		background-color: var(--sk-theme-1-variant);
 	}
 
 	button {


### PR DESCRIPTION
#439 This pull request fixes the issue where the background of the file explorer left click menu is transparent.