### PR TITLE
docs: add info link for 422 status code

### DIFF
--- a/content/tutorial/03-sveltekit/06-forms/03-form-validation/README.md
+++ b/content/tutorial/03-sveltekit/06-forms/03-form-validation/README.md
@@ -49,7 +49,7 @@ export function createTodo(userid, description) {
 
 Try submitting a duplicate todo. Yikes! SvelteKit takes us to an unfriendly-looking error page. On the server, we see a 'todos must be unique' error, but SvelteKit hides unexpected error messages from users because they often contain sensitive data.
 
-It would be much better to stay on the same page and provide an indication of what went wrong so that the user can fix it. To do this, we can use the `fail` function to return data from the action along with an appropriate HTTP status code:
+It would be much better to stay on the same page and provide an indication of what went wrong so that the user can fix it. To do this, we can use the `fail` function to return data from the action along with an appropriate HTTP status code. In this case we use the [422 Unprocessable Entity](https://httpstatusdogs.com/422-unprocessable-entity) status:
 
 ```js
 /// file: src/routes/+page.server.js


### PR DESCRIPTION
I saw that this page https://learn.svelte.dev/tutorial/post-handlers pointed to https://httpstatusdogs.com/201-created. Therefore I decided to add a link to the [422 page](https://httpstatusdogs.com/422-unprocessable-entity).
Alternatively (probably more appropriate), the cat version: https://http.cat/status/422