### PR TITLE
docs: add double quotes to type attribute

### DIFF
--- a/content/tutorial/01-svelte/06-bindings/03-checkbox-inputs/README.md
+++ b/content/tutorial/01-svelte/06-bindings/03-checkbox-inputs/README.md
@@ -6,5 +6,5 @@ Checkboxes are used for toggling between states. Instead of binding to `input.va
 
 ```svelte
 /// file: App.svelte
-<input type=checkbox +++bind:+++checked={yes}>
+<input type="checkbox" +++bind:+++checked={yes}>
 ```


### PR DESCRIPTION
the actual code is also with double quotes: https://learn.svelte.dev/tutorial/checkbox-inputs