### PR TITLE
Add definition order notice

### DIFF
--- a/content/tutorial/01-svelte/08-stores/04-derived-stores/README.md
+++ b/content/tutorial/01-svelte/08-stores/04-derived-stores/README.md
@@ -13,3 +13,5 @@ export const elapsed = derived(
 ```
 
 > It's possible to derive a store from multiple input stores, and to explicitly `set` a value instead of returning it (which is useful for deriving values asynchronously). Consult the [API reference](https://svelte.dev/docs#run-time-svelte-store-derived) for more information.
+
+> Make sure all definitions from the stores a store derives from are **before** your derived store definition. Otherwise you might end up with a `ReferenceError: Cannot access uninitialized variable.`


### PR DESCRIPTION
Add a notice telling the reader to make sure the definition order of stores and derived stores is correct.

## Describe the bug
Tauri won't load (blank window) the page if a `derived` store comes before the `writable` definition. For this reason, an addition to the tutorial page is suggested.

## Logs
```plaintext
Unhandled Promise Rejection: ReferenceError: Cannot access uninitialized variable.
```