### PR TITLE
fix inconsistency of CSS styles between initial and solved state in Part 3 / Forms / Progressive enhancement

### DIFF
--- a/content/tutorial/03-sveltekit/03-loading-data/01-page-data/README.md
+++ b/content/tutorial/03-sveltekit/03-loading-data/01-page-data/README.md
@@ -7,7 +7,7 @@ At its core, SvelteKit's job boils down to three things:
 
 1. **Routing** — figure out which route matches an incoming request
 2. **Loading** — get the data needed by the route
-3. **Rendering** - generate some HTML (on the server) or update the DOM (in the browser)
+3. **Rendering** — generate some HTML (on the server) or update the DOM (in the browser)
 
 We've seen how routing and rendering work. Let's talk about the middle part — loading.
 

--- a/content/tutorial/03-sveltekit/06-forms/04-progressive-enhancement/app-b/src/routes/+page.svelte
+++ b/content/tutorial/03-sveltekit/06-forms/04-progressive-enhancement/app-b/src/routes/+page.svelte
@@ -66,4 +66,12 @@
 		opacity: 0.5;
 		transition: opacity 0.2s;
 	}
+
+	button:hover {
+		opacity: 1;
+	}
+
+	.saving {
+		opacity: 0.5;
+	}
 </style>


### PR DESCRIPTION
### Description
- In https://learn.svelte.dev/tutorial/progressive-enhancement, the `button:hover` and `.saving` styles are omitted in the solved state, however other tutorials under the same Forms section, the styles are present in both the initial and solved states.
- This PR aims to fix the inconsistency in the said tutorial.