### PR TITLE
Fix sample code in tutorial text to match the exercise solution

### DIFF
--- a/content/tutorial/03-sveltekit/06-forms/01-the-form-element/README.md
+++ b/content/tutorial/03-sveltekit/06-forms/01-the-form-element/README.md
@@ -8,7 +8,7 @@ Let's build a todo app. We've already got an in-memory database set up in `src/l
 
 ```svelte
 /// file: src/routes/+page.svelte
-<h1>Todos</h1>
+<h1>todos</h1>
 
 +++<form method="POST">
 	<label>
@@ -20,7 +20,7 @@ Let's build a todo app. We've already got an in-memory database set up in `src/l
 	</label>
 </form>+++
 
-{#each data.todos as todo}
+<ul class="todos">
 ```
 
 If we type something into the `<input>` and hit Enter, the browser makes a POST request (because of the `method="POST"` attribute) to the current page. But that results in an error, because we haven't created a server-side _action_ to handle the POST request. Let's do that now:


### PR DESCRIPTION
This commit fix sample code in the-form-element tutorial text, which is `01-the-form-element /README.md`, to match the exercise solution, which is `01-the-form-element/app-b/src/routes/+page.svelte`.

In [the-form-element tutorial page](https://learn.svelte.dev/tutorial/the-form-element),
I found that the sample code in the text was not matched the exercise solution as we can see in the following:

Sample code in the text:
```svelte
<h1>Todos</h1>

<form method="POST">
  <label>
    add a todo:
    <input
      name="description"
      autocomplete="off"
    />
  </label>
</form>

{#each data.todos as todo}
```

Exercise solution:
```svelte
<h1>todos</h1>

<form method="POST">
  <label>
    add a todo:
    <input
      name="description"
      autocomplete="off"
    />
  </label>
</form>

<ul class="todos">
  {#each data.todos as todo (todo.id)}
```


This PR fix this mismatch.