### PR TITLE
Replace `background` with `background-color` for consistency

### DIFF
--- a/content/tutorial/02-advanced-svelte/06-classes-and-styles/04-component-styles/README.md
+++ b/content/tutorial/02-advanced-svelte/06-classes-and-styles/04-component-styles/README.md
@@ -37,7 +37,7 @@ Inside `Box.svelte`, change `background-color` so that it is determined by a [CS
 		height: 5em;
 		border-radius: 0.5em;
 		margin: 0 0 1em 0;
-		background: +++var(--color, #ddd)+++;
+		background-color: +++var(--color, #ddd)+++;
 	}
 </style>
 ```

--- a/content/tutorial/02-advanced-svelte/06-classes-and-styles/04-component-styles/app-a/src/lib/Box.svelte
+++ b/content/tutorial/02-advanced-svelte/06-classes-and-styles/04-component-styles/app-a/src/lib/Box.svelte
@@ -6,6 +6,6 @@
 		height: 5em;
 		border-radius: 0.5em;
 		margin: 0 0 1em 0;
-		background: #ddd;
+		background-color: #ddd;
 	}
 </style>

--- a/content/tutorial/02-advanced-svelte/06-classes-and-styles/04-component-styles/app-b/src/lib/Box.svelte
+++ b/content/tutorial/02-advanced-svelte/06-classes-and-styles/04-component-styles/app-b/src/lib/Box.svelte
@@ -6,6 +6,6 @@
 		height: 5em;
 		border-radius: 0.5em;
 		margin: 0 0 1em 0;
-		background: var(--color, #ddd);
+		background-color: var(--color, #ddd);
 	}
 </style>


### PR DESCRIPTION
The tutorial on *Component styles* uses `background-color` in the README.md, while the app uses the shorthand `background`. This could be confusing:

1. The text tells us to 
   > change `background-color` ...
   
   but actually changes the `background` in `Box.svelte`.

2. The first snippet uses `background-color` to overwrite `background` in `App.svelte`.  

I replaced the shorthand `background` in the app with `background-color` to make it consistent with the tutorial text.
