### PR TITLE
Access store value in context example

### DIFF
--- a/content/tutorial/02-advanced-svelte/08-context/01-context-api/README.md
+++ b/content/tutorial/02-advanced-svelte/08-context/01-context-api/README.md
@@ -86,5 +86,5 @@ import { getContext } from 'svelte';
 
 const { count } = getContext('my-context');
 
-$: console.log({ count });
+$: console.log({ count: $count });
 ```


### PR DESCRIPTION
As an alternative, `console.log({ $count })` could also be used, not sure what's best for this example.