### PR TITLE
Fix missing initial state of `updated store` tutorial

### DIFF
--- a/content/tutorial/03-sveltekit/08-stores/03-updated-store/app-b/src/routes/+layout.svelte
+++ b/content/tutorial/03-sveltekit/08-stores/03-updated-store/app-b/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { page, navigating } from '$app/stores';
+	import { page, navigating, updated } from '$app/stores';
 </script>
 
 <nav>
@@ -17,3 +17,13 @@
 </nav>
 
 <slot />
+
+{#if $updated}
+	<p class="toast">
+		A new version of the app is available
+
+		<button on:click={() => location.reload()}>
+			reload the page
+		</button>
+	</p>
+{/if}


### PR DESCRIPTION
This PRs fixes the initial state missing issue on Part 3: Basic SvelteKit > Stores > Updated store tutorial. 

It didn't have an initial state and stayed in the solved state.