### PR TITLE
fix: unavailable `--prime` css variable

### DIFF
--- a/src/routes/tutorial/[slug]/Menu.svelte
+++ b/src/routes/tutorial/[slug]/Menu.svelte
@@ -310,7 +310,7 @@
 
 	li[aria-current='page'] a,
 	li[aria-current='step']:not(.expanded) > button {
-		color: var(--prime);
+		color: var(--sk-theme-1);
 	}
 
 	li img {

--- a/src/routes/tutorial/[slug]/Sidebar.svelte
+++ b/src/routes/tutorial/[slug]/Sidebar.svelte
@@ -208,7 +208,7 @@
 
 	.modal-contents button {
 		display: block;
-		background: var(--prime);
+		background-color: var(--sk-theme-1);
 		color: white;
 		padding: 1rem;
 		width: 10em;


### PR DESCRIPTION
This patch fixes the unavailable `--prime` css variable that were being used on two files. After doing some code searches for that color, I didn't find it anywhere on `svelte.learn.dev` or in `site-kit` repo, by it's name I'm confident that `--sk-theme-1` should be it's natural replacement, but I'm available for future changes if requested.

fixes #454 

### `src/routes/tutorial/[slug]/Sidebar.svelte`

```css
.modal-contents button {
  background-color: var(--sk-theme-1);
}
```

| Before | After |
|--------|-------|
| ![01-before](https://github.com/sveltejs/learn.svelte.dev/assets/43862225/b7204d0e-fa8e-43ec-95d6-0dc9b744ef24) | ![01-after](https://github.com/sveltejs/learn.svelte.dev/assets/43862225/11e1409b-de6c-4601-b32d-f09217811478) |

---

### `src/routes/tutorial/[slug]/Menu.svelte`

```css
li[aria-current='step']:not(.expanded) > button {
  color: var(--sk-theme-1);
}
```

| Before | After |
|--------|-------|
| ![02-before](https://github.com/sveltejs/learn.svelte.dev/assets/43862225/d15333c9-7ebb-4eaf-82dc-e6e8c7018ca0) | ![02-after](https://github.com/sveltejs/learn.svelte.dev/assets/43862225/89a13731-6f30-49dc-901b-128db7756599) |

Please let me know what do you think.