### PR TITLE
chore: add license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2023 [these people](https://github.com/sveltejs/learn.svelte.dev/graphs/contributors)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This patch adds a MIT license based on SvelteKit [license](https://github.com/sveltejs/kit/blob/master/LICENSE). As suggested [here](https://github.com/sveltejs/learn.svelte.dev/issues/424#issuecomment-1633218028).
Pease let me know what do you think.

Fixes: #424 