### PR TITLE
Remove `experimental` from inspector option

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,12 +9,6 @@ const config = {
 		version: {
 			name: child_process.execSync('git rev-parse HEAD').toString().trim()
 		}
-	},
-
-	vitePlugin: {
-		inspector: {
-			holdMode: true
-		}
 	}
 };
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,10 +12,8 @@ const config = {
 	},
 
 	vitePlugin: {
-		experimental: {
-			inspector: {
-				holdMode: true
-			}
+		inspector: {
+			holdMode: true
 		}
 	}
 };


### PR DESCRIPTION
Update svelte.config.js to suppress the following warning:

> [vite-plugin-svelte] Option "vitePlugin.experimental.inspector" is no longer experimental and has moved to "vitePlugin.inspector". Please update your svelte config.