### PR TITLE
docs: clarify the meaning of content 

### DIFF
--- a/content/tutorial/02-advanced-svelte/07-composition/02-named-slots/README.md
+++ b/content/tutorial/02-advanced-svelte/07-composition/02-named-slots/README.md
@@ -4,7 +4,7 @@ title: Named slots
 
 The previous example contained a _default slot_, which renders the direct children of a component. Sometimes you will need more control over placement. In those cases, we can use _named slots_.
 
-Inside the `<App>` component, we've got `<span slot="telephone">` and others for `company` and `address`. Let's add the corresponding named slots in `Card.svelte`:
+Inside `App.svelte`, we're rendering a `<Card>` component that contains `<span slot="telephone">` and others for `company` and `address`. Let's add the corresponding named slots in `Card.svelte`:
 
 ```svelte
 /// file: Card.svelte

--- a/content/tutorial/02-advanced-svelte/07-composition/02-named-slots/README.md
+++ b/content/tutorial/02-advanced-svelte/07-composition/02-named-slots/README.md
@@ -4,7 +4,7 @@ title: Named slots
 
 The previous example contained a _default slot_, which renders the direct children of a component. Sometimes you will need more control over placement. In those cases, we can use _named slots_.
 
-Inside the `<Card>` component, we've got `<span slot="telephone">` and others for `company` and `address`. Let's add the corresponding named slots in `Card.svelte`:
+Inside the `<App>` component, we've got `<span slot="telephone">` and others for `company` and `address`. Let's add the corresponding named slots in `Card.svelte`:
 
 ```svelte
 /// file: Card.svelte


### PR DESCRIPTION
~~I think there is such a trivial matter. 
When I opened `<Card>` component file(`Card.svelte`), I got nothing related to `<span slot="telephone">` inside of that file and instead found it inside of `<App>` component!~~

**--- UPDATED (24 Aug 2023) ---**
I misunderstood the meaning of the instruction.
@geoffrich gave me a better approach. So I changed the title and description of this PR
