### PR TITLE
Update incorrect instructions in Store Bindings lesson

### DIFF
--- a/content/tutorial/01-svelte/08-stores/06-store-bindings/README.md
+++ b/content/tutorial/01-svelte/08-stores/06-store-bindings/README.md
@@ -13,7 +13,7 @@ In this example we're exporting a writable store `name` and a derived store `gre
 
 Changing the input value will now update `name` and all its dependents.
 
-We can also assign directly to store values inside a component. Add a `<button>` element after the `<input>`:
+We can also assign directly to store values inside a component. Add an `on:click` event handler to update `name`:
 
 ```svelte
 /// file: App.svelte


### PR DESCRIPTION
Edited instruction from 'add button' to 'add on:click event handler', to reflect the true diff in the code. (The button already exists; the highlighted part is the event handler)