### PR TITLE
Update README.md

### DIFF
--- a/content/tutorial/03-sveltekit/02-routing/03-params/README.md
+++ b/content/tutorial/03-sveltekit/02-routing/03-params/README.md
@@ -9,7 +9,7 @@ Let's create that file:
 
 ```svelte
 /// file: src/routes/blog/[slug]/+page.svelte
-<h1>blog post</h1>
+<h1>blog post {params.slug}</h1>
 ```
 
 We can now navigate from the `/blog` page to individual blog posts. In the next chapter, we'll see how to load their content.


### PR DESCRIPTION
This step really should show how to access the param in the page itself, as the following steps just randomly use params.slug without ever explicitly showing that's how you get the param.