### PR TITLE
fix: smaller sidebar footer horizontal padding

### DIFF
--- a/src/routes/tutorial/[slug]/Sidebar.svelte
+++ b/src/routes/tutorial/[slug]/Sidebar.svelte
@@ -181,7 +181,7 @@
 	}
 
 	footer {
-		padding: 1rem 2.8rem;
+		padding: 1rem 2.9rem;
 		display: flex;
 		justify-content: space-between;
 		background: var(--sk-back-3);

--- a/src/routes/tutorial/[slug]/Sidebar.svelte
+++ b/src/routes/tutorial/[slug]/Sidebar.svelte
@@ -181,7 +181,7 @@
 	}
 
 	footer {
-		padding: 1rem 3rem;
+		padding: 1rem 2.8rem;
 		display: flex;
 		justify-content: space-between;
 		background: var(--sk-back-3);


### PR DESCRIPTION
I thought that "Edit this page" in the sidebar footer could be moved to the left a bit.
So that it would appear more aligned with the content.

### current
<img width="370" alt="before" src="https://github.com/sveltejs/learn.svelte.dev/assets/5403694/20f0a78f-c641-4361-bf8a-05dcda73cd4f">

### this PR
<img width="450" alt="Screenshot 2023-08-25 at 23 39 42" src="https://github.com/sveltejs/learn.svelte.dev/assets/5403694/d85bb753-3e48-4742-9169-78cdc21143e4">

_(difference is in a subtle movement to left of "Edit this page" in footer)_

It's probably the smallest contribution I've ever made :D