### PR TITLE
Update README.md to match solution

### DIFF
--- a/content/tutorial/03-sveltekit/06-forms/03-form-validation/README.md
+++ b/content/tutorial/03-sveltekit/06-forms/03-form-validation/README.md
@@ -82,23 +82,24 @@ In `src/routes/+page.svelte`, we can access the returned value via the `form` pr
 	+++export let form;+++
 </script>
 
-<h1>todos</h1>
-
-+++{#if form?.error}
-	<p class="error">{form.error}</p>
-{/if}+++
-
-<form method="POST" action="?/create">
-	<label>
-		add a todo:
-		<input
-			name="description"
-			+++value={form?.description ?? ''}+++
-			autocomplete="off"
-			required
-		/>
-	</label>
-</form>
+<div class="centered">
+	<h1>todos</h1>
+	
+	+++{#if form?.error}
+		<p class="error">{form.error}</p>
+	{/if}+++
+	
+	<form method="POST" action="?/create">
+		<label>
+			add a todo:
+			<input
+				name="description"
+				+++value={form?.description ?? ''}+++
+				autocomplete="off"
+				required
+			/>
+		</label>
+	</form>
 ```
 
 > You can also return data from an action _without_ wrapping it in `fail` — for example to show a 'success!' message when data was saved — and it will be available via the `form` prop.


### PR DESCRIPTION
The readme is missing the line:

```html
<div class="centered">
``` 
as well as the indentation that are present in the code editor solution.

this can cause a slight confusion while following the tutorial