### PR TITLE
Tutorial: Let inputs and textareas follow theme coloring

### DIFF
--- a/content/tutorial/common/src/app.html
+++ b/content/tutorial/common/src/app.html
@@ -121,6 +121,7 @@
 			input,
 			textarea {
 				background: var(--bg-1);
+				color: inherit;
 			}
 
 			select:not([multiple]) {


### PR DESCRIPTION
Tiny css change in the tutorial (awesome tutorial btw!): fixes bad contrast for input text in dark mode at, e.g., [/numeric-inputs](https://learn.svelte.dev/tutorial/numeric-inputs)

Feel free to close if you prefer to fix this in another way, thought I'd just put this out there.

Current:

<img width="271" alt="image" src="https://github.com/sveltejs/learn.svelte.dev/assets/273805/cdcdbf41-29a4-4fe8-a488-60869951ecc5">


With this PR:

<img width="287" alt="image" src="https://github.com/sveltejs/learn.svelte.dev/assets/273805/0bdb45f4-bc78-40e7-85df-474c73a09dd2">

