### PR TITLE
Update paper.svg fill attr

### DIFF
--- a/content/tutorial/02-advanced-svelte/07-composition/02-named-slots/app-a/src/lib/paper.svg
+++ b/content/tutorial/02-advanced-svelte/07-composition/02-named-slots/app-a/src/lib/paper.svg
@@ -6,5 +6,5 @@
 		</feDiffuseLighting>
 	</filter>
 
-	<rect x="0" y="0" width="100%" height="100%" filter="url(#paper)" fill="none" />
+	<rect x="0" y="0" width="100%" height="100%" filter="url(#paper)" fill="white" />
 </svg>


### PR DESCRIPTION
in the tutorial excercise 'named slots', the 'paper.svg' has fill="none". The exercise is to build something that looks like a 'business card' on a table it seems, however you cannot see the card, so it looks more like words etched into wood! screenshot : https://prnt.sc/kpg6vljbZT-T