### PR TITLE
fix: restart audio playback on repeated button pushes

### DIFF
--- a/content/tutorial/01-svelte/05-events/06-dom-event-forwarding/app-a/src/lib/App.svelte
+++ b/content/tutorial/01-svelte/05-events/06-dom-event-forwarding/app-a/src/lib/App.svelte
@@ -6,6 +6,7 @@
 	audio.src = horn;
 
 	function handleClick() {
+		audio.load();
 		audio.play();
 	}
 </script>


### PR DESCRIPTION
When the button is clicked for a second time before the audio playback triggered by the first click is finished, the second click is ignored. Restarting the playback on every click makes the button feel more responsive.
Useful e.g. when the button is clicked very fast, many times in a row.