### PR TITLE
Assign the ID back when creating a new userid in cookies

### DIFF
--- a/content/tutorial/03-sveltekit/06-forms/03-form-validation/app-b/src/routes/+page.server.js
+++ b/content/tutorial/03-sveltekit/06-forms/03-form-validation/app-b/src/routes/+page.server.js
@@ -2,10 +2,12 @@ import { fail } from '@sveltejs/kit';
 import * as db from '$lib/server/database.js';
 
 export function load({ cookies }) {
-	const id = cookies.get('userid');
+	let id = cookies.get('userid');
 
 	if (!id) {
-		cookies.set('userid', crypto.randomUUID(), { path: '/' });
+		const newId = crypto.randomUUID()
+		cookies.set('userid', newId, { path: '/' });
+		id = newId
 	}
 
 	return {


### PR DESCRIPTION
Thanks for making this amazing tutorial, it's so nice!

While following the tutorial I noticed that one excersise would cause a 500 to be rendered the first time the code was loaded, as I made just one change the page would re-render and all would be fine.

Upon looking closer I noticed that map get was being called with `undefined`. 

This little change makes sure db.getTodos(id) isn't called with undefined.