### PR TITLE
Sidebar: scroll to top when exercise change

### DIFF
--- a/src/routes/tutorial/[slug]/Sidebar.svelte
+++ b/src/routes/tutorial/[slug]/Sidebar.svelte
@@ -24,7 +24,7 @@
 		// TODO ideally we would associate scroll state with
 		// history. That's a little tricky to do right now,
 		// so for now just always reset sidebar scroll
-		sidebar.scrollTop = 0;
+		sidebar.scrollIntoView();
 	});
 </script>
 


### PR DESCRIPTION
The current `scrollTop` doesn't work, but this one work with Chrome and Safari. I haven't tested on non-Chrome browsers yet.