### PR TITLE
docs: Update README.md

### DIFF
--- a/content/tutorial/01-svelte/02-reactivity/04-updating-arrays-and-objects/README.md
+++ b/content/tutorial/01-svelte/02-reactivity/04-updating-arrays-and-objects/README.md
@@ -38,9 +38,9 @@ A simple rule of thumb: the name of the updated variable must appear on the left
 
 ```js
 /// no-file
-let obj = { foo: { bar: 'old' } };
+const obj = { foo: { bar: 1 } };
 const foo = obj.foo;
-foo.bar = 'baz';
+foo.bar = 2;
 ```
 
 ...won't trigger reactivity on `obj.foo.bar`, unless you follow it up with `obj = obj`.

--- a/content/tutorial/01-svelte/02-reactivity/04-updating-arrays-and-objects/README.md
+++ b/content/tutorial/01-svelte/02-reactivity/04-updating-arrays-and-objects/README.md
@@ -38,6 +38,7 @@ A simple rule of thumb: the name of the updated variable must appear on the left
 
 ```js
 /// no-file
+let obj = { foo: { bar: 'old' } };
 const foo = obj.foo;
 foo.bar = 'baz';
 ```


### PR DESCRIPTION
# Docs: 04-updating-arrays-and-objects
Ensured clarity in the example code by defining the `obj` object. This ensures that readers understand the context and structure of the object being modified in the reactivity example.

Because it is possible to trigger reactivity by referencing `foo.bar` in the template instead of `obj.foo.bar`, the following will trigger reactivity:
```html
<script>
    let obj = { foo: { bar: 'old' } };
    const foo = obj.foo;
    
    function updateFooBar() {
        foo.bar = 'baz';
    }
</script>

<button on:click={updateFooBar}>Update foobar</button>
<!-- referencing the variable with `foo.bar` - triggers reactivity -->
<p>baz is: {foo.bar}</p>
```

However, the next example will not, and will require `obj = obj` reassignment:
```html
<script>
    let obj = { foo: { bar: 'old' } };
    const foo = obj.foo;
    
    function updateFooBar() {
        foo.bar = 'baz';
        // uncomment below to trigger reactivity
        // obj = obj 
    }
</script>

<button on:click={updateFooBar}>Update foobar</button>
<!-- referencing the variable with `obj.foo.bar` - does **not** trigger reactivity -->
<p>baz is: {obj.foo.bar}</p>
```
In this case, `{obj.foo.bar}` does not trigger reactivity when `foo.bar` is updated, unless `obj` is reassigned (with `obj = obj`).

By including the definition of the `obj` object, we aim to elucidate the structure and context in which the reactivity example operates, ensuring a clearer understanding for the reader.