### PR TITLE
add aria-role:none to get rid of warning

### DIFF
--- a/content/tutorial/02-advanced-svelte/01-motion/02-springs/app-a/src/lib/App.svelte
+++ b/content/tutorial/02-advanced-svelte/01-motion/02-springs/app-a/src/lib/App.svelte
@@ -11,6 +11,7 @@
 	}}
 	on:mousedown={() => size.set(30)}
 	on:mouseup={() => size.set(10)}
+	role="none"
 >
 	<circle
 		cx={$coords.x}

--- a/content/tutorial/02-advanced-svelte/01-motion/02-springs/app-a/src/lib/App.svelte
+++ b/content/tutorial/02-advanced-svelte/01-motion/02-springs/app-a/src/lib/App.svelte
@@ -11,7 +11,7 @@
 	}}
 	on:mousedown={() => size.set(30)}
 	on:mouseup={() => size.set(10)}
-	role="none"
+	role="presentation"
 >
 	<circle
 		cx={$coords.x}

--- a/content/tutorial/02-advanced-svelte/01-motion/02-springs/app-b/src/lib/App.svelte
+++ b/content/tutorial/02-advanced-svelte/01-motion/02-springs/app-b/src/lib/App.svelte
@@ -15,6 +15,7 @@
 	}}
 	on:mousedown={() => size.set(30)}
 	on:mouseup={() => size.set(10)}
+	role="none"
 >
 	<circle
 		cx={$coords.x}

--- a/content/tutorial/02-advanced-svelte/01-motion/02-springs/app-b/src/lib/App.svelte
+++ b/content/tutorial/02-advanced-svelte/01-motion/02-springs/app-b/src/lib/App.svelte
@@ -15,7 +15,7 @@
 	}}
 	on:mousedown={() => size.set(30)}
 	on:mouseup={() => size.set(10)}
-	role="none"
+	role="presentation"
 >
 	<circle
 		cx={$coords.x}


### PR DESCRIPTION
Gets rid of this warning:
![image](https://github.com/sveltejs/learn.svelte.dev/assets/43886029/e5939087-fa7f-402e-8c39-089ac648cb00)

"presentation" might be better suited here according to ChatGPT: https://chat.openai.com/share/fad5f67a-2f7e-45a4-a759-18e5b9aa44cb
> **presentation:** If the SVG is purely decorative and doesn't convey meaningful content or functionality.
**none:** Similar to **presentation**, used when the SVG doesn't have a direct role for assistive technologies.