### PR TITLE
Fix: sidebar scrolls to top after navigate

### DIFF
--- a/src/routes/tutorial/[slug]/Sidebar.svelte
+++ b/src/routes/tutorial/[slug]/Sidebar.svelte
@@ -24,7 +24,7 @@
 		// TODO ideally we would associate scroll state with
 		// history. That's a little tricky to do right now,
 		// so for now just always reset sidebar scroll
-		sidebar.scrollTop = 0;
+		sidebar.scrollIntoView();
 	});
 </script>
 


### PR DESCRIPTION
Fix for sidebar should scroll to top after navigate:

Current Issue:
The current sidebar in tutorial doesn't scroll back to top when clicking `next` tutorial. 
User needs to scroll back to top manually, which is not convenient, e.g.
- Clicking `Next: tick` on sidebar in [https://learn.svelte.dev/tutorial/update](https://learn.svelte.dev/tutorial/update), the scrollbar in sidebar doesn't get scrolled to top in next tutorial

This fix should resolve the issue.