### PR TITLE
fix: sidebar scrolls to top after navigate

### DIFF
--- a/src/routes/tutorial/[slug]/Sidebar.svelte
+++ b/src/routes/tutorial/[slug]/Sidebar.svelte
@@ -25,7 +25,6 @@
 		// history. That's a little tricky to do right now,
 		// so for now just always reset sidebar scroll
 		sidebar.scrollTop = 0;
-		console.log(sidebar);
 	});
 </script>
 

--- a/src/routes/tutorial/[slug]/Sidebar.svelte
+++ b/src/routes/tutorial/[slug]/Sidebar.svelte
@@ -25,14 +25,14 @@
 		// history. That's a little tricky to do right now,
 		// so for now just always reset sidebar scroll
 		sidebar.scrollTop = 0;
+		console.log(sidebar);
 	});
 </script>
 
 <Menu {index} current={exercise} />
 
-<section>
+<section bind:this={sidebar}>
 	<div
-		bind:this={sidebar}
 		class="text"
 		on:copy={(e) => {
 			if (sessionStorage[copy_enabled]) return;


### PR DESCRIPTION
This change resolves issue #528 by binding the whole 'section' element to the 'sidebar' variable
