### PR TITLE
add something to do on updated-store tutorial

### DIFF
--- a/content/tutorial/03-sveltekit/08-stores/03-updated-store/README.md
+++ b/content/tutorial/03-sveltekit/08-stores/03-updated-store/README.md
@@ -4,38 +4,29 @@ title: updated
 
 The `updated` store contains `true` or `false` depending on whether a new version of the app has been deployed since the page was first opened. For this to work, your `svelte.config.js` must specify `kit.version.pollInterval`.
 
+```svelte
+/// file: src/routes/+layout.svelte
+<script>
+	import { page, navigating, +++updated+++ } from '$app/stores';
+</script>
+```
+
 Version changes only happen in production, not during development. For that reason, `$updated` will always be `false` in this tutorial.
 
 You can manually check for new versions, regardless of `pollInterval`, by calling `updated.check()`.
 
 ```svelte
 /// file: src/routes/+layout.svelte
-<script>
-	import { page, navigating, +++updated+++ } from '$app/stores';
-</script>
 
-<nav>
-	<a href="/" aria-current={$page.url.pathname === '/'}>
-		home
-	</a>
++++{#if $updated}+++
+	<div class="toast">
+		<p>
+			A new version of the app is available
 
-	<a href="/about" aria-current={$page.url.pathname === '/about'}>
-		about
-	</a>
-
-	{#if $navigating}
-		navigating to {$navigating.to.url.pathname}
-	{/if}
-</nav>
-
-<slot />
-
-+++{#if $updated}
-	<p class="toast">
-		A new version of the app is available
-
-		<button on:click={() => location.reload()}>
-			reload the page
-		</button>
-	</p>
-{/if}+++
+			<button on:click={() => location.reload()}>
+				reload the page
+			</button>
+		</p>
+	</div>
++++{/if}+++
+```

--- a/content/tutorial/03-sveltekit/08-stores/03-updated-store/app-b/src/routes/+layout.svelte
+++ b/content/tutorial/03-sveltekit/08-stores/03-updated-store/app-b/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { page, navigating } from '$app/stores';
+	import { page, navigating, updated } from '$app/stores';
 </script>
 
 <nav>
@@ -18,15 +18,17 @@
 
 <slot />
 
-<div class="toast">
-	<p>
-		A new version of the app is available
+{#if $updated}
+	<div class="toast">
+		<p>
+			A new version of the app is available
 
-		<button on:click={() => location.reload()}>
-			reload the page
-		</button>
-	</p>
-</div>
+			<button on:click={() => location.reload()}>
+				reload the page
+			</button>
+		</p>
+	</div>
+{/if}
 
 <style>
 	.toast {


### PR DESCRIPTION
this is an alternative to #477 — we can't _really_ show `$updated` in action, but we can communicate the gist of it by _starting_ with the toast visible, and then wrapping the toast in `{#if $updated}`. it does a better job than the current version of walking you through it, and gives you something to do