### PR TITLE
Fix duplicated code snippet

### DIFF
--- a/content/tutorial/03-sveltekit/06-forms/04-progressive-enhancement/README.md
+++ b/content/tutorial/03-sveltekit/06-forms/04-progressive-enhancement/README.md
@@ -25,11 +25,6 @@ Import the `enhance` function from `$app/forms`...
 <form method="POST" action="?/create" +++use:enhance+++>
 ```
 
-```svelte
-/// file: src/routes/+page.svelte
-<form method="POST" action="?/delete" +++use:enhance+++>
-```
-
 And that's all it takes! Now, when JavaScript is enabled, `use:enhance` will emulate the browser-native behaviour except for the full-page reloads. It will:
 
 - update the `form` prop


### PR DESCRIPTION
### Why
Correct me if I'm wrong but currently in the `Part 3 / Forms / Progressive enhancement` part, the instruction code snippet seems duplicated.
https://learn.svelte.dev/tutorial/progressive-enhancement

<img width="528" alt="image" src="https://github.com/sveltejs/learn.svelte.dev/assets/11817656/9419ce01-a1c4-4886-b194-97df53a02aa4">

### What
Remove the duplicated code snippet.