### PR TITLE
docs: adjust div class value for consistency

### DIFF
--- a/content/tutorial/02-advanced-svelte/07-composition/01-slots/README.md
+++ b/content/tutorial/02-advanced-svelte/07-composition/01-slots/README.md
@@ -15,7 +15,7 @@ Just like elements can have children...
 
 ```svelte
 /// file: Card.svelte
-<div class="card ">
+<div class="card">
 	+++<slot />+++
 </div>
 ```


### PR DESCRIPTION
While going through the [Slots](https://learn.svelte.dev/tutorial/slots) section, I noticed the values of the `div` class were inconsistent.

The text has a space in the value, `<div class="card ">`.

While the `Card.svelte` file didn't have any spaces, `<div class="card">`.

### Tutorial Text
![Card.svelte code snippet](https://github.com/sveltejs/learn.svelte.dev/assets/56709653/8ce6be40-0055-4461-9f9e-3ca8afcb6577)

### Tutorial File `Card.svelte`
![Card.svelte source file](https://github.com/sveltejs/learn.svelte.dev/assets/56709653/533ae848-cedb-4e11-9e6e-fd03d4d89070)
