### PR TITLE
docs: add code snippet for removing if blocks

### DIFF
--- a/content/tutorial/02-advanced-svelte/09-special-elements/02-svelte-component/README.md
+++ b/content/tutorial/02-advanced-svelte/09-special-elements/02-svelte-component/README.md
@@ -28,6 +28,12 @@ We _could_ do this with a sequence of `if` blocks...
 </select>
 
 +++<svelte:component this={selected.component}/>+++
+
+---{#if selected.color === 'red'}
+	<RedThing />
+{:else}
+	<p>TODO others</p>
+{/if}---
 ```
 
 The `this` value can be any component constructor, or a falsy value — if it's falsy, no component is rendered.

--- a/content/tutorial/02-advanced-svelte/09-special-elements/03-svelte-element/README.md
+++ b/content/tutorial/02-advanced-svelte/09-special-elements/03-svelte-element/README.md
@@ -15,6 +15,12 @@ Similarly, we don't always know in advance what kind of DOM element to render. `
 +++<svelte:element this={selected}>
 	I'm a <code>&lt;{selected}&gt;</code> element
 </svelte:element>+++
+
+---{#if selected === 'h1'}
+	<h1>I'm a <code>&lt;h1&gt;</code> element</h1>
+{:else}
+	<p>TODO others</p>
+{/if}---
 ```
 
 The `this` value can be any string, or a falsy value — if it's falsy, no element is rendered.


### PR DESCRIPTION
In the [svelte:component](https://learn.svelte.dev/tutorial/svelte-component) and [svelte:element](https://learn.svelte.dev/tutorial/svelte-element) sections, the tutorial is missing the step to remove the `if blocks` after adding `<svelte:component>` and `<svelte:element>` respectively.

This PR adds a step to `remove if blocks` in the shown code snippets.

## Behavior
- Following the current state of the tutorial doesn't `solve` the problem.
- The problem is only `solved` after removing the `if blocks`, which the tutorial does not indicate.
- There is a duplicate element as shown in the images below, since we don't remove the `if blocks`.

## Images
Observe the following from the images:
- code snippet for `App.svelte` file.
- output of the source files, which displays the additional element from the `if block`.

### <svelte:component>
![<svelte:component>](https://github.com/sveltejs/learn.svelte.dev/assets/56709653/24c66256-a755-425e-b368-64671fc6ab38)

### <svelte:element>
![<svelte:element>](https://github.com/sveltejs/learn.svelte.dev/assets/56709653/69f940fe-df16-4b2f-a194-1c52c0403747)

