### PR TITLE
docs: update code snippet for consistency with source file

### DIFF
--- a/content/tutorial/02-advanced-svelte/10-module-context/02-module-exports/README.md
+++ b/content/tutorial/02-advanced-svelte/10-module-context/02-module-exports/README.md
@@ -21,6 +21,7 @@ We can now import `stopAll` in `App.svelte`...
 /// file: App.svelte
 <script>
 	import AudioPlayer, +++{ stopAll }+++ from './AudioPlayer.svelte';
+	import { tracks } from './tracks.js';
 </script>
 ```
 


### PR DESCRIPTION
In the [module exports](https://learn.svelte.dev/tutorial/module-exports) section, the code snippet in the tutorial content is inconsistent with the source file.

### App.svelte code snippet
![App.svelte code snippet](https://github.com/sveltejs/learn.svelte.dev/assets/56709653/74e5fb7e-f67e-4ad5-994a-ba25847509a0)

### App.svelte source file
![App.svelte source file](https://github.com/sveltejs/learn.svelte.dev/assets/56709653/a8ac3a55-55cd-4952-ad91-740c84bf1313)
