### PR TITLE
Update AudioPlayer.svelte: fix: begin playing sound again on ended

### DIFF
--- a/content/tutorial/02-advanced-svelte/05-bindings/03-media-elements/app-b/src/lib/AudioPlayer.svelte
+++ b/content/tutorial/02-advanced-svelte/05-bindings/03-media-elements/app-b/src/lib/AudioPlayer.svelte
@@ -25,7 +25,7 @@
 		bind:paused
 		preload="metadata"
 		on:ended={() => {
-			time = 0;
+			paused = false;
 		}}
 	/>
 	


### PR DESCRIPTION
Bug: on:ended the time was set to 0 but after the audio/video ends the audio/video is paused automatically.

Fix: on:ended the audio/video needs to be unpaused again.