### PR TITLE
Svelte 5 POC

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"devDependencies": {
 		"@playwright/test": "^1.37.1",
 		"@sveltejs/adapter-vercel": "3.0.3",
-		"@sveltejs/kit": "^1.24.1",
+		"@sveltejs/kit": "^1.27.0",
 		"@sveltejs/site-kit": "6.0.0-next.39",
 		"@types/diff": "^5.0.3",
 		"@types/prismjs": "^1.26.0",
@@ -27,8 +27,8 @@
 		"prettier": "^3.0.3",
 		"prettier-plugin-svelte": "^3.0.3",
 		"shiki-twoslash": "^3.1.2",
-		"svelte": "^4.2.0",
-		"svelte-check": "^3.5.1",
+		"svelte": "^5.0.0-next.31",
+		"svelte-check": "^3.6.0",
 		"tiny-glob": "^0.2.9",
 		"typescript": "^5.2.2",
 		"vite": "^4.4.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,10 +58,10 @@ dependencies:
     version: 6.0.14(@codemirror/commands@6.2.5)(@codemirror/language@6.9.0)(@codemirror/search@6.5.2)(@codemirror/state@6.2.1)(@codemirror/view@6.17.1)
   '@rich_harris/svelte-split-pane':
     specifier: ^1.1.1
-    version: 1.1.1(svelte@4.2.0)
+    version: 1.1.1(svelte@5.0.0-next.31)
   '@sveltejs/repl':
     specifier: ^0.6.0
-    version: 0.6.0(@codemirror/lang-html@6.4.6)(@codemirror/search@6.5.2)(@lezer/common@1.0.4)(@lezer/javascript@1.4.7)(@lezer/lr@1.3.10)(@sveltejs/kit@1.24.1)(svelte@4.2.0)
+    version: 0.6.0(@codemirror/lang-html@6.4.6)(@codemirror/search@6.5.2)(@lezer/common@1.0.4)(@lezer/javascript@1.4.7)(@lezer/lr@1.3.10)(@sveltejs/kit@1.30.3)(svelte@5.0.0-next.31)
   '@webcontainer/api':
     specifier: ^1.1.5
     version: 1.1.5
@@ -105,13 +105,13 @@ devDependencies:
     version: 1.37.1
   '@sveltejs/adapter-vercel':
     specifier: 3.0.3
-    version: 3.0.3(@sveltejs/kit@1.24.1)
+    version: 3.0.3(@sveltejs/kit@1.30.3)
   '@sveltejs/kit':
-    specifier: ^1.24.1
-    version: 1.24.1(svelte@4.2.0)(vite@4.4.9)
+    specifier: ^1.27.0
+    version: 1.30.3(svelte@5.0.0-next.31)(vite@4.4.9)
   '@sveltejs/site-kit':
     specifier: 6.0.0-next.39
-    version: 6.0.0-next.39(@sveltejs/kit@1.24.1)(svelte@4.2.0)
+    version: 6.0.0-next.39(@sveltejs/kit@1.30.3)(svelte@5.0.0-next.31)
   '@types/diff':
     specifier: ^5.0.3
     version: 5.0.3
@@ -138,16 +138,16 @@ devDependencies:
     version: 3.0.3
   prettier-plugin-svelte:
     specifier: ^3.0.3
-    version: 3.0.3(prettier@3.0.3)(svelte@4.2.0)
+    version: 3.0.3(prettier@3.0.3)(svelte@5.0.0-next.31)
   shiki-twoslash:
     specifier: ^3.1.2
     version: 3.1.2(typescript@5.2.2)
   svelte:
-    specifier: ^4.2.0
-    version: 4.2.0
+    specifier: ^5.0.0-next.31
+    version: 5.0.0-next.31
   svelte-check:
-    specifier: ^3.5.1
-    version: 3.5.1(svelte@4.2.0)
+    specifier: ^3.6.0
+    version: 3.6.2(svelte@5.0.0-next.31)
   tiny-glob:
     specifier: ^0.2.9
     version: 0.2.9
@@ -660,6 +660,10 @@ packages:
     dev: true
     optional: true
 
+  /@fastify/busboy@2.1.0:
+    resolution: {integrity: sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==}
+    engines: {node: '>=14'}
+
   /@fontsource/roboto-mono@5.0.8:
     resolution: {integrity: sha512-vjnNX8zQCSp4HadUJ3gpZiizCsK/ROjgGMpd4bcRxuyiTNGGMaznmKbhqdyVeFVap1sX8h2Qu380awaotey/mQ==}
     dev: false
@@ -860,12 +864,12 @@ packages:
       '@codemirror/view': 6.17.1
     dev: false
 
-  /@rich_harris/svelte-split-pane@1.1.1(svelte@4.2.0):
+  /@rich_harris/svelte-split-pane@1.1.1(svelte@5.0.0-next.31):
     resolution: {integrity: sha512-y2RRLyrN6DCeIgwA423aAIv/T5JqQeOl2XogBQ/21DvA2IF7oyrLUtXMxmQL2va2NFdeJO6MDx6nDX5X7kau7A==}
     peerDependencies:
       svelte: ^3.54.0
     dependencies:
-      svelte: 4.2.0
+      svelte: 5.0.0-next.31
     dev: false
 
   /@rollup/browser@3.28.1:
@@ -880,12 +884,12 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@sveltejs/adapter-vercel@3.0.3(@sveltejs/kit@1.24.1):
+  /@sveltejs/adapter-vercel@3.0.3(@sveltejs/kit@1.30.3):
     resolution: {integrity: sha512-0FQMjR6klW4627ewdclSr0lUe/DqiiyOaRTfgb5cXgNbVMsZMOA2fQ77TYQnJdvMfSEWe6y8uznV48XqKh9+vA==}
     peerDependencies:
       '@sveltejs/kit': ^1.5.0
     dependencies:
-      '@sveltejs/kit': 1.24.1(svelte@4.2.0)(vite@4.4.9)
+      '@sveltejs/kit': 1.30.3(svelte@5.0.0-next.31)(vite@4.4.9)
       '@vercel/nft': 0.23.1
       esbuild: 0.18.20
     transitivePeerDependencies:
@@ -893,34 +897,34 @@ packages:
       - supports-color
     dev: true
 
-  /@sveltejs/kit@1.24.1(svelte@4.2.0)(vite@4.4.9):
-    resolution: {integrity: sha512-u2FO0q62Se9UZ0g9kXaWYi+54vTK70BKaPScOcx6jLMRou4CUZgDTNKnRhsbJgPMgaLkOH0j3o/fKlZ6jBfgSg==}
+  /@sveltejs/kit@1.30.3(svelte@5.0.0-next.31)(vite@4.4.9):
+    resolution: {integrity: sha512-0DzVXfU4h+tChFvoc8C61IqErCyskD4ydSIDjpKS2lYlEzIYrtYrY7juSqACFxqcvZAnOEXvSY+zZ8br0+ZMMg==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     requiresBuild: true
     peerDependencies:
-      svelte: ^3.54.0 || ^4.0.0-next.0
+      svelte: ^3.54.0 || ^4.0.0-next.0 || ^5.0.0-next.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.5(svelte@4.2.0)(vite@4.4.9)
+      '@sveltejs/vite-plugin-svelte': 2.5.3(svelte@5.0.0-next.31)(vite@4.4.9)
       '@types/cookie': 0.5.2
       cookie: 0.5.0
       devalue: 4.3.2
       esm-env: 1.0.0
       kleur: 4.1.5
       magic-string: 0.30.3
-      mime: 3.0.0
+      mrmime: 1.0.1
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 2.0.3
-      svelte: 4.2.0
+      svelte: 5.0.0-next.31
       tiny-glob: 0.2.9
-      undici: 5.23.0
+      undici: 5.26.5
       vite: 4.4.9(lightningcss@1.21.7)
     transitivePeerDependencies:
       - supports-color
 
-  /@sveltejs/repl@0.6.0(@codemirror/lang-html@6.4.6)(@codemirror/search@6.5.2)(@lezer/common@1.0.4)(@lezer/javascript@1.4.7)(@lezer/lr@1.3.10)(@sveltejs/kit@1.24.1)(svelte@4.2.0):
+  /@sveltejs/repl@0.6.0(@codemirror/lang-html@6.4.6)(@codemirror/search@6.5.2)(@lezer/common@1.0.4)(@lezer/javascript@1.4.7)(@lezer/lr@1.3.10)(@sveltejs/kit@1.30.3)(svelte@5.0.0-next.31):
     resolution: {integrity: sha512-NADKN0NZhLlSatTSh5CCsdzgf2KHJFRef/8krA/TVWAWos5kSwmZ5fF0UImuqs61Pu/SiMXksaWNTGTiOtr4fQ==}
     peerDependencies:
       svelte: ^3.54.0 || ^4.0.0-next.0 || ^4.0.0
@@ -940,17 +944,17 @@ packages:
       '@neocodemirror/svelte': 0.0.15(@codemirror/autocomplete@6.9.0)(@codemirror/commands@6.2.5)(@codemirror/language@6.9.0)(@codemirror/lint@6.4.1)(@codemirror/search@6.5.2)(@codemirror/state@6.2.1)(@codemirror/view@6.17.1)
       '@replit/codemirror-lang-svelte': 6.0.0(@codemirror/autocomplete@6.9.0)(@codemirror/lang-css@6.2.1)(@codemirror/lang-html@6.4.6)(@codemirror/lang-javascript@6.2.1)(@codemirror/language@6.9.0)(@codemirror/state@6.2.1)(@codemirror/view@6.17.1)(@lezer/common@1.0.4)(@lezer/highlight@1.1.6)(@lezer/javascript@1.4.7)(@lezer/lr@1.3.10)
       '@replit/codemirror-vim': 6.0.14(@codemirror/commands@6.2.5)(@codemirror/language@6.9.0)(@codemirror/search@6.5.2)(@codemirror/state@6.2.1)(@codemirror/view@6.17.1)
-      '@rich_harris/svelte-split-pane': 1.1.1(svelte@4.2.0)
+      '@rich_harris/svelte-split-pane': 1.1.1(svelte@5.0.0-next.31)
       '@rollup/browser': 3.28.1
-      '@sveltejs/site-kit': 5.2.2(@sveltejs/kit@1.24.1)(svelte@4.2.0)
+      '@sveltejs/site-kit': 5.2.2(@sveltejs/kit@1.30.3)(svelte@5.0.0-next.31)
       acorn: 8.10.0
       codemirror: 6.0.1(@lezer/common@1.0.4)
       esm-env: 1.0.0
       estree-walker: 3.0.3
       marked: 5.1.2
       resolve.exports: 2.0.2
-      svelte: 4.2.0
-      svelte-json-tree: 2.1.0(svelte@4.2.0)
+      svelte: 5.0.0-next.31
+      svelte-json-tree: 2.1.0(svelte@5.0.0-next.31)
     transitivePeerDependencies:
       - '@codemirror/lang-html'
       - '@codemirror/search'
@@ -960,31 +964,31 @@ packages:
       - '@sveltejs/kit'
     dev: false
 
-  /@sveltejs/site-kit@5.2.2(@sveltejs/kit@1.24.1)(svelte@4.2.0):
+  /@sveltejs/site-kit@5.2.2(@sveltejs/kit@1.30.3)(svelte@5.0.0-next.31):
     resolution: {integrity: sha512-XLLxVUV/dYytCsUeODAkjtzlaIBSn1kdcH5U36OuN7gMsPEHDy5L/dsWjf1/vDln3JStH5lqZPEN8Fovm33KhA==}
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
       svelte: ^3.54.0
     dependencies:
-      '@sveltejs/kit': 1.24.1(svelte@4.2.0)(vite@4.4.9)
+      '@sveltejs/kit': 1.30.3(svelte@5.0.0-next.31)(vite@4.4.9)
       esm-env: 1.0.0
-      svelte: 4.2.0
-      svelte-local-storage-store: 0.4.0(svelte@4.2.0)
+      svelte: 5.0.0-next.31
+      svelte-local-storage-store: 0.4.0(svelte@5.0.0-next.31)
     dev: false
 
-  /@sveltejs/site-kit@6.0.0-next.39(@sveltejs/kit@1.24.1)(svelte@4.2.0):
+  /@sveltejs/site-kit@6.0.0-next.39(@sveltejs/kit@1.30.3)(svelte@5.0.0-next.31):
     resolution: {integrity: sha512-HARhb2WayjHL/3BFjffFO5cMJjbkPrN/01Tz8Oe3mZYmAUD4Cb3iUI34p415ASTIO6RAeDnClBZDwr2EsK6spg==}
     peerDependencies:
       '@sveltejs/kit': ^1.20.0
       svelte: ^4.0.0
     dependencies:
-      '@sveltejs/kit': 1.24.1(svelte@4.2.0)(vite@4.4.9)
+      '@sveltejs/kit': 1.30.3(svelte@5.0.0-next.31)(vite@4.4.9)
       esm-env: 1.0.0
-      svelte: 4.2.0
-      svelte-local-storage-store: 0.6.0(svelte@4.2.0)
+      svelte: 5.0.0-next.31
+      svelte-local-storage-store: 0.6.0(svelte@5.0.0-next.31)
     dev: true
 
-  /@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.5)(svelte@4.2.0)(vite@4.4.9):
+  /@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.5.3)(svelte@5.0.0-next.31)(vite@4.4.9):
     resolution: {integrity: sha512-zjiuZ3yydBtwpF3bj0kQNV0YXe+iKE545QGZVTaylW3eAzFr+pJ/cwK8lZEaRp4JtaJXhD5DyWAV4AxLh6DgaQ==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
@@ -992,27 +996,27 @@ packages:
       svelte: ^3.54.0 || ^4.0.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.5(svelte@4.2.0)(vite@4.4.9)
+      '@sveltejs/vite-plugin-svelte': 2.5.3(svelte@5.0.0-next.31)(vite@4.4.9)
       debug: 4.3.4
-      svelte: 4.2.0
+      svelte: 5.0.0-next.31
       vite: 4.4.9(lightningcss@1.21.7)
     transitivePeerDependencies:
       - supports-color
 
-  /@sveltejs/vite-plugin-svelte@2.4.5(svelte@4.2.0)(vite@4.4.9):
-    resolution: {integrity: sha512-UJKsFNwhzCVuiZd06jM/psscyNJNDwjQC+qIeb7GBJK9iWeQCcIyfcPWDvbCudfcJggY9jtxJeeaZH7uny93FQ==}
+  /@sveltejs/vite-plugin-svelte@2.5.3(svelte@5.0.0-next.31)(vite@4.4.9):
+    resolution: {integrity: sha512-erhNtXxE5/6xGZz/M9eXsmI7Pxa6MS7jyTy06zN3Ck++ldrppOnOlJwHHTsMC7DHDQdgUp4NAc4cDNQ9eGdB/w==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
-      svelte: ^3.54.0 || ^4.0.0
+      svelte: ^3.54.0 || ^4.0.0 || ^5.0.0-next.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.5)(svelte@4.2.0)(vite@4.4.9)
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.5.3)(svelte@5.0.0-next.31)(vite@4.4.9)
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.3
-      svelte: 4.2.0
-      svelte-hmr: 0.15.3(svelte@4.2.0)
+      svelte: 5.0.0-next.31
+      svelte-hmr: 0.15.3(svelte@5.0.0-next.31)
       vite: 4.4.9(lightningcss@1.21.7)
       vitefu: 0.2.4(vite@4.4.9)
     transitivePeerDependencies:
@@ -1105,6 +1109,13 @@ packages:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
     dev: true
 
+  /acorn-typescript@1.4.13(acorn@8.10.0):
+    resolution: {integrity: sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==}
+    peerDependencies:
+      acorn: '>=8.9.0'
+    dependencies:
+      acorn: 8.10.0
+
   /acorn@8.10.0:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
@@ -1166,8 +1177,8 @@ packages:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
     dev: true
 
-  /axobject-query@3.2.1:
-    resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
+  /axobject-query@4.0.0:
+    resolution: {integrity: sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==}
     dependencies:
       dequal: 2.0.3
 
@@ -1219,12 +1230,6 @@ packages:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
     dev: true
 
-  /busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-    dependencies:
-      streamsearch: 1.1.0
-
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -1253,15 +1258,6 @@ packages:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
     dev: true
-
-  /code-red@1.0.4:
-    resolution: {integrity: sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
-      '@types/estree': 1.0.1
-      acorn: 8.10.0
-      estree-walker: 3.0.3
-      periscopic: 3.1.0
 
   /codemirror@6.0.1(@lezer/common@1.0.4):
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
@@ -1297,13 +1293,6 @@ packages:
   /crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
     dev: false
-
-  /css-tree@2.3.1:
-    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
-    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
-    dependencies:
-      mdn-data: 2.0.30
-      source-map-js: 1.0.2
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
@@ -1438,6 +1427,12 @@ packages:
   /esm-env@1.0.0:
     resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
 
+  /esrap@1.2.1:
+    resolution: {integrity: sha512-dhkcOLfN/aDdMFI1iwPEcy/XqAZzGNfgfEJjZozy2tia6u0dQoZyXzkRshHTckuNsM+c0CYQndY+uRFe3N+AIQ==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@types/estree': 1.0.1
+
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
     dev: true
@@ -1446,6 +1441,7 @@ packages:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
     dependencies:
       '@types/estree': 1.0.1
+    dev: false
 
   /fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -1615,8 +1611,8 @@ packages:
     engines: {node: '>=0.12.0'}
     dev: true
 
-  /is-reference@3.0.1:
-    resolution: {integrity: sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==}
+  /is-reference@3.0.2:
+    resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
     dependencies:
       '@types/estree': 1.0.1
 
@@ -1731,15 +1727,14 @@ packages:
     hasBin: true
     dev: true
 
-  /magic-string@0.27.0:
-    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+  /magic-string@0.30.3:
+    resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
-  /magic-string@0.30.3:
-    resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -1763,9 +1758,6 @@ packages:
     hasBin: true
     dev: false
 
-  /mdn-data@2.0.30:
-    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
-
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1778,11 +1770,6 @@ packages:
       braces: 3.0.2
       picomatch: 2.3.1
     dev: true
-
-  /mime@3.0.0:
-    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
 
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -1919,13 +1906,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /periscopic@3.1.0:
-    resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
-    dependencies:
-      '@types/estree': 1.0.1
-      estree-walker: 3.0.3
-      is-reference: 3.0.1
-
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
@@ -1952,14 +1932,14 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
-  /prettier-plugin-svelte@3.0.3(prettier@3.0.3)(svelte@4.2.0):
+  /prettier-plugin-svelte@3.0.3(prettier@3.0.3)(svelte@5.0.0-next.31):
     resolution: {integrity: sha512-dLhieh4obJEK1hnZ6koxF+tMUrZbV5YGvRpf2+OADyanjya5j0z1Llo8iGwiHmFWZVG/hLEw/AJD5chXd9r3XA==}
     peerDependencies:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0
     dependencies:
       prettier: 3.0.3
-      svelte: 4.2.0
+      svelte: 5.0.0-next.31
     dev: true
 
   /prettier@3.0.3:
@@ -2131,10 +2111,6 @@ packages:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
 
-  /streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
-
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -2172,11 +2148,11 @@ packages:
     resolution: {integrity: sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==}
     dev: false
 
-  /svelte-check@3.5.1(svelte@4.2.0):
-    resolution: {integrity: sha512-+Zb4iHxAhdUtcUg/WJPRjlS1RJalIsWAe9Mz6G1zyznSs7dDkT7VUBdXc3q7Iwg49O/VrZgyJRvOJkjuBfKjFA==}
+  /svelte-check@3.6.2(svelte@5.0.0-next.31):
+    resolution: {integrity: sha512-E6iFh4aUCGJLRz6QZXH3gcN/VFfkzwtruWSRmlKrLWQTiO6VzLsivR6q02WYLGNAGecV3EocqZuCDrC2uttZ0g==}
     hasBin: true
     peerDependencies:
-      svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0
+      svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
     dependencies:
       '@jridgewell/trace-mapping': 0.3.19
       chokidar: 3.5.3
@@ -2184,8 +2160,8 @@ packages:
       import-fresh: 3.3.0
       picocolors: 1.0.0
       sade: 1.8.1
-      svelte: 4.2.0
-      svelte-preprocess: 5.0.4(svelte@4.2.0)(typescript@5.2.2)
+      svelte: 5.0.0-next.31
+      svelte-preprocess: 5.1.3(svelte@5.0.0-next.31)(typescript@5.2.2)
       typescript: 5.2.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -2199,55 +2175,55 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-hmr@0.15.3(svelte@4.2.0):
+  /svelte-hmr@0.15.3(svelte@5.0.0-next.31):
     resolution: {integrity: sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: ^3.19.0 || ^4.0.0
     dependencies:
-      svelte: 4.2.0
+      svelte: 5.0.0-next.31
 
-  /svelte-json-tree@2.1.0(svelte@4.2.0):
+  /svelte-json-tree@2.1.0(svelte@5.0.0-next.31):
     resolution: {integrity: sha512-IAU//hE5bIA0SoM9AuP7xOoD9PUcMh4fio0oI52r0XJ7iNDytW7AnBdkIn1QSYLUyWzvQX3tp59JfLYfhd7lTw==}
     peerDependencies:
       svelte: ^4.0.0
     dependencies:
-      svelte: 4.2.0
+      svelte: 5.0.0-next.31
     dev: false
 
-  /svelte-local-storage-store@0.4.0(svelte@4.2.0):
+  /svelte-local-storage-store@0.4.0(svelte@5.0.0-next.31):
     resolution: {integrity: sha512-ctPykTt4S3BE5bF0mfV0jKiUR1qlmqLvnAkQvYHLeb9wRyO1MdIFDVI23X+TZEFleATHkTaOpYZswIvf3b2tWA==}
     engines: {node: '>=0.14'}
     peerDependencies:
       svelte: ^3.48.0
     dependencies:
-      svelte: 4.2.0
+      svelte: 5.0.0-next.31
     dev: false
 
-  /svelte-local-storage-store@0.6.0(svelte@4.2.0):
+  /svelte-local-storage-store@0.6.0(svelte@5.0.0-next.31):
     resolution: {integrity: sha512-UbCY/yT/YUadU5IX/gZkoRQnA+ebFZHKKQjlJvfWHnBj3CPe9sNn8ndxYz/xy4LUzGjuBLq8+wH5RYK54ba3wA==}
     engines: {node: '>=0.14'}
     peerDependencies:
       svelte: ^3.48.0 || ^4.0.0
     dependencies:
-      svelte: 4.2.0
+      svelte: 5.0.0-next.31
     dev: true
 
-  /svelte-preprocess@5.0.4(svelte@4.2.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
-    engines: {node: '>= 14.10.0'}
+  /svelte-preprocess@5.1.3(svelte@5.0.0-next.31)(typescript@5.2.2):
+    resolution: {integrity: sha512-xxAkmxGHT+J/GourS5mVJeOXZzne1FR5ljeOUAMXUkfEhkLEllRreXpbl3dIYJlcJRfL1LO1uIAPpBpBfiqGPw==}
+    engines: {node: '>= 16.0.0', pnpm: ^8.0.0}
     requiresBuild: true
     peerDependencies:
       '@babel/core': ^7.10.2
       coffeescript: ^2.5.1
       less: ^3.11.3 || ^4.0.0
       postcss: ^7 || ^8
-      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
+      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
       pug: ^3.0.0
       sass: ^1.26.8
       stylus: ^0.55.0
       sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0
+      svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
       typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
     peerDependenciesMeta:
       '@babel/core':
@@ -2273,30 +2249,29 @@ packages:
     dependencies:
       '@types/pug': 2.0.6
       detect-indent: 6.1.0
-      magic-string: 0.27.0
+      magic-string: 0.30.5
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 4.2.0
+      svelte: 5.0.0-next.31
       typescript: 5.2.2
     dev: true
 
-  /svelte@4.2.0:
-    resolution: {integrity: sha512-kVsdPjDbLrv74SmLSUzAsBGquMs4MPgWGkGLpH+PjOYnFOziAvENVzgJmyOCV2gntxE32aNm8/sqNKD6LbIpeQ==}
-    engines: {node: '>=16'}
+  /svelte@5.0.0-next.31:
+    resolution: {integrity: sha512-8DksQKZ5HPNzUXvN/laq85Rf5G1d2/rXP1yodlLdJZBwmwmvuNS9l+bRvclOowH0wg1UO8kdr+3t4KFzRFlCtA==}
+    engines: {node: '>=18'}
     dependencies:
       '@ampproject/remapping': 2.2.1
       '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.19
       acorn: 8.10.0
+      acorn-typescript: 1.4.13(acorn@8.10.0)
       aria-query: 5.3.0
-      axobject-query: 3.2.1
-      code-red: 1.0.4
-      css-tree: 2.3.1
-      estree-walker: 3.0.3
-      is-reference: 3.0.1
+      axobject-query: 4.0.0
+      esm-env: 1.0.0
+      esrap: 1.2.1
+      is-reference: 3.0.2
       locate-character: 3.0.0
-      magic-string: 0.30.3
-      periscopic: 3.1.0
+      magic-string: 0.30.5
+      zimmerframe: 1.1.0
 
   /tar@6.1.15:
     resolution: {integrity: sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==}
@@ -2337,11 +2312,11 @@ packages:
     hasBin: true
     dev: true
 
-  /undici@5.23.0:
-    resolution: {integrity: sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==}
+  /undici@5.26.5:
+    resolution: {integrity: sha512-cSb4bPFd5qgR7qr2jYAi0hlX9n5YKK2ONKkLFkxl+v/9BvC0sOpZjBHDBSXc5lWAf5ty9oZdRXytBIHzgUcerw==}
     engines: {node: '>=14.0'}
     dependencies:
-      busboy: 1.6.0
+      '@fastify/busboy': 2.1.0
 
   /update-browserslist-db@1.0.11(browserslist@4.21.10):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
@@ -2456,3 +2431,6 @@ packages:
   /yootils@0.3.1:
     resolution: {integrity: sha512-A7AMeJfGefk317I/3tBoUYRcDcNavKEkpiPN/nQsBz/viI2GvT7BtrqdPD6rGqBFN8Ax7v4obf+Cl32JF9DDVw==}
     dev: false
+
+  /zimmerframe@1.1.0:
+    resolution: {integrity: sha512-+AmV37r9NPUy7KcuG0Fde9AAFSD88kN5pnqvD7Pkp5WLLK0jct7hAtIDXXFDCRk3l5Mc1r2Sth3gfP2ZLE+/Qw==}

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -1,6 +1,9 @@
 <script>
 	import { onMount } from 'svelte';
 
+	/** @type {{ onclose?: () => void; children?: import('svelte').Snippet }}*/
+	let { onclose } = $props();
+
 	/** @type {HTMLDialogElement} */
 	let modal;
 
@@ -41,7 +44,7 @@
 
 <div class="modal-background" />
 
-<dialog class="modal" tabindex="-1" bind:this={modal} on:close>
+<dialog class="modal" tabindex="-1" bind:this={modal} {onclose}>
 	<slot />
 </dialog>
 

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -1,8 +1,8 @@
 <script>
 	import { onMount } from 'svelte';
 
-	/** @type {{ onclose?: () => void; children?: import('svelte').Snippet }}*/
-	let { onclose } = $props();
+	/** @type {{ onclose?: () => void; children: import('svelte').Snippet }}*/
+	let { onclose, children } = $props();
 
 	/** @type {HTMLDialogElement} */
 	let modal;
@@ -45,7 +45,7 @@
 <div class="modal-background" />
 
 <dialog class="modal" tabindex="-1" bind:this={modal} {onclose}>
-	<slot />
+	{@render children()}
 </dialog>
 
 <style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,7 +8,7 @@
 	import '@sveltejs/site-kit/styles/index.css';
 	import '../app.css';
 
-	let { data } = $props();
+	let { data, children } = $props();
 </script>
 
 <Shell>
@@ -46,7 +46,7 @@
 		</svelte:fragment>
 	</Nav>
 
-	<slot />
+	{@render children()}
 </Shell>
 
 {#if browser}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,7 +8,7 @@
 	import '@sveltejs/site-kit/styles/index.css';
 	import '../app.css';
 
-	export let data;
+	let { data } = $props();
 </script>
 
 <Shell>

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -20,22 +20,29 @@
 		solution
 	} from './state.js';
 
-	export let data;
+	let { data } = $props();
 
 	let path = data.exercise.path;
-	let show_editor = false;
-	let show_filetree = false;
-	let paused = false;
-	let w = 1000;
+	let show_editor = $state(false);
+	let show_filetree = $state(false);
+	let paused = $state(false);
+	let w = $state(1000);
 
 	/** @type {import('$lib/types').Stub[]} */
 	let previous_files = [];
 
-	$: mobile = w < 800; // for the things we can't do with media queries
-	$: files.set(Object.values(data.exercise.a));
-	$: solution.set(data.exercise.b);
-	$: selected_name.set(data.exercise.focus);
-	$: completed = is_completed($files, data.exercise.b);
+	let mobile = $derived(w < 800); // for the things we can't do with media queries
+	let completed = $derived(is_completed($files, data.exercise.b));
+
+	// meh: I have to duplicate this because $effect.pre doesn't run on the server
+	files.set(Object.values(data.exercise.a));
+	solution.set(data.exercise.b);
+	selected_name.set(data.exercise.focus);
+	$effect.pre(() => {
+		files.set(Object.values(data.exercise.a));
+		solution.set(data.exercise.b);
+		selected_name.set(data.exercise.focus);
+	});
 
 	beforeNavigate(() => {
 		previous_files = $files;

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -111,7 +111,7 @@
 		show_editor = true;
 	}
 
-	/** @param {string} name */
+	/** @param {string | null} name */
 	function navigate_to_file(name) {
 		if (name === s.selected_name) return;
 
@@ -158,7 +158,7 @@
 
 <svelte:window
 	bind:innerWidth={w}
-	on:popstate={(e) => {
+	onpopstate={(e) => {
 		const q = new URLSearchParams(location.search);
 		const file = q.get('file');
 
@@ -181,8 +181,8 @@
 					bind:sidebar
 					index={data.index}
 					exercise={data.exercise}
-					on:select={(e) => {
-						navigate_to_file(e.detail.file);
+					on_select={(file) => {
+						navigate_to_file(file);
 					}}
 				/>
 			</section>
@@ -199,7 +199,7 @@
 						>
 							<section class="navigator" slot="a">
 								{#if mobile}
-									<button class="file" on:click={() => (show_filetree = !show_filetree)}>
+									<button class="file" onclick={() => (show_filetree = !show_filetree)}>
 										{s.selected_file?.name.replace(
 											data.exercise.scope.prefix,
 											data.exercise.scope.name + '/'
@@ -208,8 +208,8 @@
 								{:else}
 									<Filetree
 										exercise={data.exercise}
-										on:select={(e) => {
-											select_file(e.detail.name);
+										on_select={(name) => {
+											select_file(name);
 										}}
 									/>
 								{/if}
@@ -218,7 +218,7 @@
 									class="solve"
 									class:completed
 									disabled={!data.exercise.has_solution}
-									on:click={() => {
+									onclick={() => {
 										reset_files(Object.values(completed ? data.exercise.a : data.exercise.b));
 									}}
 								>
@@ -239,8 +239,8 @@
 										<Filetree
 											mobile
 											exercise={data.exercise}
-											on:select={(e) => {
-												navigate_to_file(e.detail.name);
+											on_select={(name) => {
+												navigate_to_file(name);
 											}}
 										/>
 									</div>
@@ -259,8 +259,8 @@
 
 	<div class="screen-toggle">
 		<ScreenToggle
-			on:change={(e) => {
-				show_editor = e.detail.pressed;
+			on_change={(pressed) => {
+				show_editor = pressed;
 
 				const url = new URL(location.origin + location.pathname);
 

--- a/src/routes/tutorial/[slug]/Chrome.svelte
+++ b/src/routes/tutorial/[slug]/Chrome.svelte
@@ -1,17 +1,20 @@
 <script>
-	import { createEventDispatcher } from 'svelte';
-
-	/** @type {{path: string; loading: boolean; href: string | null;}}*/
-	let { path, loading, href } = $props();
-
-	const dispatch = createEventDispatcher();
+	/** @type {{
+	 * 	path: string;
+	 * 	loading: boolean;
+	 * 	href: string | null;
+	 * 	on_refresh?: () => void;
+	 * 	on_change?: (value: string) => void;
+	 * 	on_toggle_terminal?: () => void;
+	 * }}*/
+	let { path, loading, href, on_refresh, on_change, on_toggle_terminal } = $props();
 </script>
 
 <div class="chrome" class:loading>
 	<button
 		disabled={loading}
 		class="reload icon"
-		on:click={() => dispatch('refresh')}
+		onclick={() => on_refresh?.()}
 		aria-label="reload"
 	/>
 
@@ -19,13 +22,13 @@
 		disabled={loading}
 		aria-label="URL"
 		value={path}
-		on:change={(e) => {
-			dispatch('change', { value: e.currentTarget.value });
+		onchange={(e) => {
+			on_change?.(e.currentTarget.value);
 		}}
-		on:keydown={(e) => {
+		onkeydown={(e) => {
 			if (e.key !== 'Enter') return;
 
-			dispatch('change', { value: e.currentTarget.value });
+			on_change?.(e.currentTarget.value);
 			e.currentTarget.blur();
 		}}
 	/>
@@ -41,7 +44,7 @@
 	<button
 		disabled={loading}
 		class="terminal icon"
-		on:click={() => dispatch('toggle_terminal')}
+		onclick={() => on_toggle_terminal?.()}
 		aria-label="toggle terminal"
 	/>
 </div>

--- a/src/routes/tutorial/[slug]/Chrome.svelte
+++ b/src/routes/tutorial/[slug]/Chrome.svelte
@@ -1,20 +1,19 @@
 <script>
 	import { createEventDispatcher } from 'svelte';
 
-	/** @type {string} */
-	export let path;
-
-	/** @type {boolean} */
-	export let loading;
-
-	/** @type {string | null} */
-	export let href;
+	/** @type {{path: string; loading: boolean; href: string | null;}}*/
+	let { path, loading, href } = $props();
 
 	const dispatch = createEventDispatcher();
 </script>
 
 <div class="chrome" class:loading>
-	<button disabled={loading} class="reload icon" on:click={() => dispatch('refresh')} aria-label="reload" />
+	<button
+		disabled={loading}
+		class="reload icon"
+		on:click={() => dispatch('refresh')}
+		aria-label="reload"
+	/>
 
 	<input
 		disabled={loading}
@@ -31,7 +30,13 @@
 		}}
 	/>
 
-	<a {href} class="new-tab icon" target="_blank" aria-label={href ? 'open in new tab' : undefined} tabindex="0" />
+	<a
+		{href}
+		class="new-tab icon"
+		target="_blank"
+		aria-label={href ? 'open in new tab' : undefined}
+		tabindex="0"
+	/>
 
 	<button
 		disabled={loading}
@@ -69,7 +74,8 @@
 		border: 2px solid var(--sk-theme-3);
 	}
 
-	.icon, .icon::after {
+	.icon,
+	.icon::after {
 		position: relative;
 		height: 100%;
 		aspect-ratio: 1;

--- a/src/routes/tutorial/[slug]/Editor.svelte
+++ b/src/routes/tutorial/[slug]/Editor.svelte
@@ -30,8 +30,7 @@
 	/** @type {Map<string, import('@codemirror/state').EditorState>} */
 	let editor_states = new Map();
 
-	/** @type {import('@codemirror/view').EditorView} */
-	let editor_view;
+	let editor_view = /** @type {import('@codemirror/view').EditorView} */ ($state());
 
 	const extensions = [
 		basicSetup,
@@ -41,33 +40,39 @@
 		svelteTheme
 	];
 
-	$: reset($files);
+	$effect.pre(() => {
+		reset($files);
+	});
 
-	$: select_state($selected_name);
+	$effect.pre(() => {
+		select_state($selected_name);
+	});
 
-	$: if (editor_view) {
-		if ($selected_name) {
-			const current_warnings = $warnings[$selected_name];
+	$effect.pre(() => {
+		if (editor_view) {
+			if ($selected_name) {
+				const current_warnings = $warnings[$selected_name];
 
-			if (current_warnings) {
-				const diagnostics = current_warnings.map((warning) => {
-					/** @type {import('@codemirror/lint').Diagnostic} */
-					const diagnostic = {
-						from: warning.start.character,
-						to: warning.end.character,
-						severity: 'warning',
-						message: warning.message
-					};
+				if (current_warnings) {
+					const diagnostics = current_warnings.map((warning) => {
+						/** @type {import('@codemirror/lint').Diagnostic} */
+						const diagnostic = {
+							from: warning.start.character,
+							to: warning.end.character,
+							severity: 'warning',
+							message: warning.message
+						};
 
-					return diagnostic;
-				});
+						return diagnostic;
+					});
 
-				const transaction = setDiagnostics(editor_view.state, diagnostics);
+					const transaction = setDiagnostics(editor_view.state, diagnostics);
 
-				editor_view.dispatch(transaction);
+					editor_view.dispatch(transaction);
+				}
 			}
 		}
-	}
+	});
 
 	let installed_vim = false;
 

--- a/src/routes/tutorial/[slug]/Editor.svelte
+++ b/src/routes/tutorial/[slug]/Editor.svelte
@@ -203,12 +203,12 @@
 </script>
 
 <svelte:window
-	on:pointerdown={(e) => {
+	onpointerdown={(e) => {
 		if (!container.contains(/** @type {HTMLElement} */ (e.target))) {
 			preserve_editor_focus = false;
 		}
 	}}
-	on:message={(e) => {
+	onmessage={(e) => {
 		if (preserve_editor_focus && e.data.type === 'iframe_took_focus') {
 			editor_view.focus();
 		}
@@ -218,11 +218,11 @@
 <div
 	class="container"
 	bind:this={container}
-	on:focusin={() => {
+	onfocusin={() => {
 		clearTimeout(remove_focus_timeout);
 		preserve_editor_focus = true;
 	}}
-	on:focusout={() => {
+	onfocusout={() => {
 		// Heuristic: user did refocus themmselves if iframe_took_focus
 		// doesn't happen in the next few miliseconds. Needed
 		// because else navigations inside the iframe refocus the editor.

--- a/src/routes/tutorial/[slug]/ImageViewer.svelte
+++ b/src/routes/tutorial/[slug]/ImageViewer.svelte
@@ -1,6 +1,6 @@
 <script>
-	/** @type {import('$lib/types').FileStub | null} */
-	export let selected;
+	/** @type {{selected: import('$lib/types').FileStub | null;}} */
+	let { selected } = $props();
 
 	const image_types = new Map([
 		// TODO add more
@@ -11,9 +11,9 @@
 		['.webp', 'image/webp']
 	]);
 
-	$: ext = selected?.basename.slice(selected.basename.lastIndexOf('.'));
-	$: image_type = ext && image_types.get(ext);
-	$: image = image_type && selected;
+	const ext = $derived(selected?.basename.slice(selected.basename.lastIndexOf('.')));
+	const image_type = $derived(ext && image_types.get(ext));
+	const image = $derived(image_type && selected);
 </script>
 
 {#if image}

--- a/src/routes/tutorial/[slug]/Loading.svelte
+++ b/src/routes/tutorial/[slug]/Loading.svelte
@@ -1,21 +1,11 @@
 <script>
-	import { afterNavigate } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { Icon } from '@sveltejs/site-kit/components';
 
-	/** @type {boolean} */
-	export let initial;
+	/** @type {{initial: boolean; error: Error | null; progress: number; status: string}}*/
+	let { initial, error, progress, status } = $props();
 
-	/** @type {Error | null} */
-	export let error;
-
-	/** @type {number} */
-	export let progress;
-
-	/** @type {string} */
-	export let status;
-
-	$: is_svelte = /Part (1|2)/.test($page.data.exercise.part.title);
+	const is_svelte = $derived(/Part (1|2)/.test($page.data.exercise.part.title));
 </script>
 
 <div class="loading">

--- a/src/routes/tutorial/[slug]/Menu.svelte
+++ b/src/routes/tutorial/[slug]/Menu.svelte
@@ -44,7 +44,7 @@
 
 		<button
 			class="heading"
-			on:click={() => ($is_mobile ? open_nav() : (is_open = !is_open))}
+			onclick={() => ($is_mobile ? open_nav() : (is_open = !is_open))}
 			class:open={is_open}
 		>
 			<h1>
@@ -87,7 +87,8 @@
 									transition:slide={{ duration }}
 								>
 									<button
-										on:click|stopPropagation={() => {
+										onclick={(e) => {
+											e.stopPropagation();
 											if (expanded_part !== part.slug) {
 												expanded_part = part.slug;
 												expanded_chapter = part.chapters[0].slug;
@@ -106,7 +107,10 @@
 													aria-current={chapter.slug === current.chapter.slug ? 'step' : undefined}
 												>
 													<button
-														on:click|stopPropagation={() => (expanded_chapter = chapter.slug)}
+														onclick={(e) => {
+															e.stopPropagation();
+															expanded_chapter = chapter.slug;
+														}}
 														style="width: 100%; text-align: start;"
 													>
 														<!-- <img src={arrow} alt="Arrow icon" /> -->
@@ -126,7 +130,7 @@
 																>
 																	<a
 																		href="/tutorial/{exercise.slug}"
-																		on:click={() => (is_open = false)}
+																		onclick={() => (is_open = false)}
 																	>
 																		{exercise.title}
 																	</a>

--- a/src/routes/tutorial/[slug]/Menu.svelte
+++ b/src/routes/tutorial/[slug]/Menu.svelte
@@ -7,20 +7,24 @@
 	import { expoOut } from 'svelte/easing';
 	import { slide } from 'svelte/transition';
 
-	/** @type {import('$lib/types').PartStub[]}*/
-	export let index;
-
-	/** @type {import('$lib/types').Exercise} */
-	export let current;
+	/** @type {{index: import('$lib/types').PartStub[]; current: import('$lib/types').Exercise;}}*/
+	let { index, current } = $props();
 
 	const is_mobile = mql('(max-width: 800px)');
 
 	const duration = $reduced_motion ? 0 : 200;
 
-	let is_open = false;
+	let is_open = $state(false);
 
-	$: expanded_part = current.part.slug;
-	$: expanded_chapter = current.chapter.slug;
+	let expanded_part = $state(current.part.slug);
+	$effect.pre(() => {
+		expanded_part = current.part.slug;
+	});
+
+	let expanded_chapter = $state(current.chapter.slug);
+	$effect.pre(() => {
+		expanded_chapter = current.chapter.slug;
+	});
 </script>
 
 <div

--- a/src/routes/tutorial/[slug]/Output.svelte
+++ b/src/routes/tutorial/[slug]/Output.svelte
@@ -7,22 +7,20 @@
 	import Loading from './Loading.svelte';
 	import { base, error, logs, progress, subscribe } from './adapter';
 
-	/** @type {import('$lib/types').Exercise} */
-	export let exercise;
+	/** @type {{exercise: import('$lib/types').Exercise; paused: boolean;}}*/
+	let { exercise, paused } = $props();
 
-	/** @type {boolean} */
-	export let paused;
-
-	/** @type {HTMLIFrameElement} */
-	let iframe;
-	let loading = true;
+	let iframe = /** @type {HTMLIFrameElement} */ ($state());
+	let loading = $state(true);
 	let initial = true;
-	let terminal_visible = false;
+	let terminal_visible = $state(false);
 
 	// reset `path` to `exercise.path` each time, but allow it to be controlled by the iframe
-	let path = exercise.path;
+	let path = $state(exercise.path);
 
-	$: if ($base) set_iframe_src($base + (path = exercise.path));
+	$effect.pre(() => {
+		if ($base) set_iframe_src($base + (path = exercise.path));
+	});
 
 	onMount(() => {
 		const unsubscribe = subscribe('reload', () => {
@@ -51,7 +49,7 @@
 		} catch {}
 	}
 
-	$: change_theme($theme);
+	$effect.pre(() => change_theme($theme));
 
 	/** @type {any} */
 	let timeout;

--- a/src/routes/tutorial/[slug]/Output.svelte
+++ b/src/routes/tutorial/[slug]/Output.svelte
@@ -5,7 +5,7 @@
 	import { onMount } from 'svelte';
 	import Chrome from './Chrome.svelte';
 	import Loading from './Loading.svelte';
-	import { base, error, logs, progress, subscribe } from './adapter';
+	import { a, subscribe } from './adapter.svelte';
 
 	/** @type {{exercise: import('$lib/types').Exercise; paused: boolean;}}*/
 	let { exercise, paused } = $props();
@@ -19,12 +19,12 @@
 	let path = $state(exercise.path);
 
 	$effect.pre(() => {
-		if ($base) set_iframe_src($base + (path = exercise.path));
+		if (a.base) set_iframe_src(a.base + (path = exercise.path));
 	});
 
 	onMount(() => {
 		const unsubscribe = subscribe('reload', () => {
-			set_iframe_src($base + path);
+			set_iframe_src(a.base + path);
 		});
 
 		return () => {
@@ -56,7 +56,7 @@
 
 	/** @param {MessageEvent} e */
 	async function handle_message(e) {
-		if (e.origin !== $base) return;
+		if (e.origin !== a.base) return;
 
 		if (paused) return;
 
@@ -71,7 +71,7 @@
 
 				// we lost contact, refresh the page
 				loading = true;
-				set_iframe_src($base + path);
+				set_iframe_src(a.base + path);
 				loading = false;
 			}, 1000);
 		} else if (e.data.type === 'ping-pause') {
@@ -113,18 +113,18 @@
 <Chrome
 	{path}
 	{loading}
-	href={$base && $base + path}
+	href={a.base && a.base + path}
 	on:refresh={() => {
-		set_iframe_src($base + path);
+		set_iframe_src(a.base + path);
 	}}
 	on:toggle_terminal={() => {
 		terminal_visible = !terminal_visible;
 	}}
 	on:change={(e) => {
-		if ($base) {
-			const url = new URL(e.detail.value, $base);
+		if (a.base) {
+			const url = new URL(e.detail.value, a.base);
 			path = url.pathname + url.search + url.hash;
-			set_iframe_src($base + path);
+			set_iframe_src(a.base + path);
 		}
 	}}
 />
@@ -134,12 +134,12 @@
 		<iframe bind:this={iframe} title="Output" on:load={set_iframe_visible} />
 	{/if}
 
-	{#if paused || loading || $error}
-		<Loading {initial} error={$error} progress={$progress.value} status={$progress.text} />
+	{#if paused || loading || a.error}
+		<Loading {initial} error={a.error} progress={a.progress.value} status={a.progress.text} />
 	{/if}
 
 	<div class="terminal" class:visible={terminal_visible}>
-		{#each $logs as log}
+		{#each a.logs as log}
 			<div>{@html log}</div>
 		{/each}
 	</div>

--- a/src/routes/tutorial/[slug]/Output.svelte
+++ b/src/routes/tutorial/[slug]/Output.svelte
@@ -85,7 +85,7 @@
 
 		// To prevent iframe flickering.
 		// Set to `visible` by calling `set_iframe_visible` function
-		// from iframe on:load or setTimeout
+		// from iframe onload or setTimeout
 		iframe.style.visibility = 'hidden';
 		setTimeout(set_iframe_visible, 1000);
 
@@ -109,20 +109,20 @@
 	}
 </script>
 
-<svelte:window on:message={handle_message} />
+<svelte:window onmessage={handle_message} />
 <Chrome
 	{path}
 	{loading}
 	href={a.base && a.base + path}
-	on:refresh={() => {
+	on_refresh={() => {
 		set_iframe_src(a.base + path);
 	}}
-	on:toggle_terminal={() => {
+	on_toggle_terminal={() => {
 		terminal_visible = !terminal_visible;
 	}}
-	on:change={(e) => {
+	on_change={(value) => {
 		if (a.base) {
-			const url = new URL(e.detail.value, a.base);
+			const url = new URL(value, a.base);
 			path = url.pathname + url.search + url.hash;
 			set_iframe_src(a.base + path);
 		}
@@ -131,7 +131,7 @@
 
 <div class="content">
 	{#if browser}
-		<iframe bind:this={iframe} title="Output" on:load={set_iframe_visible} />
+		<iframe bind:this={iframe} title="Output" onload={set_iframe_visible} />
 	{/if}
 
 	{#if paused || loading || a.error}

--- a/src/routes/tutorial/[slug]/ScreenToggle.svelte
+++ b/src/routes/tutorial/[slug]/ScreenToggle.svelte
@@ -1,30 +1,27 @@
 <script>
-	import { createEventDispatcher } from 'svelte';
 	import ToggleButton from './ToggleButton.svelte';
 
-	/** @type {{pressed: boolean}} */
-	let { pressed = false } = $props();
-
-	const dispatch = createEventDispatcher();
+	/** @type {{pressed: boolean; on_change?: (pressed: boolean) => void}} */
+	let { pressed = false, on_change } = $props();
 </script>
 
 <div class="input-output-toggle">
 	<button
 		aria-hidden="true"
-		on:click={() => {
+		onclick={() => {
 			if (pressed) {
 				pressed = false;
-				dispatch('change', { pressed });
+				on_change?.(pressed);
 			}
 		}}>Tutorial</button
 	>
-	<ToggleButton label="Show editor" {pressed} on:change />
+	<ToggleButton label="Show editor" {pressed} {on_change} />
 	<button
 		aria-hidden="true"
-		on:click={() => {
+		onclick={() => {
 			if (!pressed) {
 				pressed = true;
-				dispatch('change', { pressed });
+				on_change?.(pressed);
 			}
 		}}>Editor</button
 	>

--- a/src/routes/tutorial/[slug]/ScreenToggle.svelte
+++ b/src/routes/tutorial/[slug]/ScreenToggle.svelte
@@ -2,8 +2,8 @@
 	import { createEventDispatcher } from 'svelte';
 	import ToggleButton from './ToggleButton.svelte';
 
-	/** @type {boolean} */
-	export let pressed = false;
+	/** @type {{pressed: boolean}} */
+	let { pressed = false } = $props();
 
 	const dispatch = createEventDispatcher();
 </script>

--- a/src/routes/tutorial/[slug]/Sidebar.svelte
+++ b/src/routes/tutorial/[slug]/Sidebar.svelte
@@ -3,21 +3,15 @@
 	import Modal from '$lib/components/Modal.svelte';
 	import Menu from './Menu.svelte';
 
-	/** @type {import('$lib/types').PartStub[]} */
-	export let index;
-
-	/** @type {import('$lib/types').Exercise} */
-	export let exercise;
-
-	/** @type {HTMLElement} */
-	export let sidebar;
+	/** @type {{ index: import('$lib/types').PartStub[]; exercise: import('$lib/types').Exercise; sidebar: HTMLElement }}*/
+	let { index, exercise, sidebar } = $props();
 
 	const dispatch = createEventDispatcher();
 
 	const namespace = 'learn.svelte.dev';
 	const copy_enabled = `${namespace}:copy_enabled`;
 
-	let show_modal = false;
+	let show_modal = $state(false);
 </script>
 
 <Menu {index} current={exercise} />

--- a/src/routes/tutorial/[slug]/Sidebar.svelte
+++ b/src/routes/tutorial/[slug]/Sidebar.svelte
@@ -1,12 +1,9 @@
 <script>
-	import { createEventDispatcher } from 'svelte';
 	import Modal from '$lib/components/Modal.svelte';
 	import Menu from './Menu.svelte';
 
-	/** @type {{ index: import('$lib/types').PartStub[]; exercise: import('$lib/types').Exercise; sidebar: HTMLElement }}*/
-	let { index, exercise, sidebar } = $props();
-
-	const dispatch = createEventDispatcher();
+	/** @type {{ index: import('$lib/types').PartStub[]; exercise: import('$lib/types').Exercise; sidebar: HTMLElement; on_select?: (file: string) => void }}*/
+	let { index, exercise, sidebar, on_select } = $props();
 
 	const namespace = 'learn.svelte.dev';
 	const copy_enabled = `${namespace}:copy_enabled`;
@@ -19,7 +16,7 @@
 <section bind:this={sidebar}>
 	<div
 		class="text"
-		on:copy={(e) => {
+		oncopy={(e) => {
 			if (sessionStorage[copy_enabled]) return;
 
 			/** @type {HTMLElement | null} */
@@ -40,19 +37,19 @@
 		<!-- svelte-ignore a11y-click-events-have-key-events -->
 		<!-- svelte-ignore a11y-no-static-element-interactions -->
 		<div
-			on:click={(e) => {
+			onclick={(e) => {
 				const node = /** @type {HTMLElement} */ (e.target);
 
 				if (node.nodeName === 'CODE') {
 					const { file } = node.dataset;
 					if (file) {
-						dispatch('select', { file });
+						on_select?.(file);
 					}
 				}
 
 				if (node.nodeName === 'SPAN' && node.classList.contains('filename')) {
 					const file = exercise.scope.prefix + node.textContent;
-					dispatch('select', { file });
+					on_select?.(file);
 				}
 			}}
 		>
@@ -77,7 +74,7 @@
 </section>
 
 {#if show_modal}
-	<Modal on:close={() => (show_modal = false)}>
+	<Modal onclose={() => (show_modal = false)}>
 		<div class="modal-contents">
 			<h2>Copy and paste is currently disabled!</h2>
 
@@ -88,14 +85,14 @@
 			<label>
 				<input
 					type="checkbox"
-					on:change={(e) => {
+					onchange={(e) => {
 						sessionStorage[copy_enabled] = e.currentTarget.checked ? 'true' : '';
 					}}
 				/>
 				enable copy-and-paste for the duration of this session
 			</label>
 
-			<button on:click={() => (show_modal = false)}>OK</button>
+			<button onclick={() => (show_modal = false)}>OK</button>
 		</div>
 	</Modal>
 {/if}

--- a/src/routes/tutorial/[slug]/ToggleButton.svelte
+++ b/src/routes/tutorial/[slug]/ToggleButton.svelte
@@ -1,18 +1,14 @@
 <!-- TODO this is copied from kit.svelte.dev — probably belongs in site-kit -->
 <script>
-	import { createEventDispatcher } from 'svelte';
-
-	/** @type {{ label: string; pressed: boolean }} */
-	let { label, pressed = false } = $props();
-
-	const dispatch = createEventDispatcher();
+	/** @type {{ label: string; pressed: boolean; on_change?: (pressed: boolean) => void; }} */
+	let { label, pressed = false, on_change } = $props();
 </script>
 
 <button
 	aria-pressed={pressed ? 'true' : 'false'}
-	on:click={() => {
+	onclick={() => {
 		pressed = !pressed;
-		dispatch('change', { pressed });
+		on_change?.(pressed);
 	}}
 >
 	<span class="visually-hidden">{label}</span>

--- a/src/routes/tutorial/[slug]/ToggleButton.svelte
+++ b/src/routes/tutorial/[slug]/ToggleButton.svelte
@@ -2,10 +2,8 @@
 <script>
 	import { createEventDispatcher } from 'svelte';
 
-	/** @type {string} */
-	export let label;
-
-	export let pressed = false;
+	/** @type {{ label: string; pressed: boolean }} */
+	let { label, pressed = false } = $props();
 
 	const dispatch = createEventDispatcher();
 </script>
@@ -72,8 +70,12 @@
 		left: 2px;
 		border-radius: 50%;
 		background: var(--fg);
-		box-shadow: 0 0px 1px rgba(0, 0, 0, 0.4), 0 4px 2px rgba(0, 0, 0, 0.1);
-		transition: background 0.2s ease-out, left 0.2s ease-out;
+		box-shadow:
+			0 0px 1px rgba(0, 0, 0, 0.4),
+			0 4px 2px rgba(0, 0, 0, 0.1);
+		transition:
+			background 0.2s ease-out,
+			left 0.2s ease-out;
 	}
 
 	button[aria-pressed='true']::after {

--- a/src/routes/tutorial/[slug]/adapter.svelte.js
+++ b/src/routes/tutorial/[slug]/adapter.svelte.js
@@ -1,22 +1,15 @@
-import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
 
-export const progress = writable({
-	value: 0,
-	text: 'initialising'
+export const a = $state({
+	progress: {
+		value: 0,
+		text: 'initialising'
+	},
+	base: /** @type {string | null} */ (null),
+	error: /** @type {Error | null} */ (null),
+	logs: /** @type {string[]} */ ([]),
+	warnings: /** @type {Record<string, import('./state.svelte').CompilerWarning[]>} */ ({})
 });
-
-/** @type {import('svelte/store').Writable<string | null>} */
-export const base = writable(null);
-
-/** @type {import('svelte/store').Writable<Error | null>} */
-export const error = writable(null);
-
-/** @type {import('svelte/store').Writable<string[]>} */
-export const logs = writable([]);
-
-/** @type {import('svelte/store').Writable<Record<string, import('./state').CompilerWarning[]>>} */
-export const warnings = writable({});
 
 /** @type {Promise<import('$lib/types').Adapter>} */
 let ready = new Promise(() => {});
@@ -25,7 +18,7 @@ if (browser) {
 	ready = new Promise(async (fulfil, reject) => {
 		try {
 			const module = await import('$lib/client/adapters/webcontainer/index.js');
-			const adapter = await module.create(base, error, progress, logs, warnings);
+			const adapter = await module.create(a);
 
 			fulfil(adapter);
 		} catch (error) {
@@ -71,9 +64,9 @@ export async function reset(files) {
 			publish('reload');
 		}
 
-		error.set(null);
+		a.error = null;
 	} catch (e) {
-		error.set(/** @type {Error} */ (e));
+		a.error = /** @type {Error} */ (e);
 	}
 }
 

--- a/src/routes/tutorial/[slug]/filetree/ContextMenu.svelte
+++ b/src/routes/tutorial/[slug]/filetree/ContextMenu.svelte
@@ -29,7 +29,7 @@
 			<ul>
 				{#each menu_items.items as item}
 					<li>
-						<button on:click={item.fn}>{item.label}</button>
+						<button onclick={item.fn}>{item.label}</button>
 					</li>
 				{/each}
 			</ul>
@@ -37,7 +37,7 @@
 	</nav>
 {/if}
 
-<svelte:window on:click={() => (menu_items = null)} />
+<svelte:window onclick={() => (menu_items = null)} />
 
 <style>
 	.navbar {

--- a/src/routes/tutorial/[slug]/filetree/ContextMenu.svelte
+++ b/src/routes/tutorial/[slug]/filetree/ContextMenu.svelte
@@ -2,16 +2,14 @@
      A context menu for the tutorial's file tree
 -->
 <script context="module">
-	import { writable } from 'svelte/store';
-
 	/**
 	 * @typedef {{ icon: string; label: string; fn: () => void }} MenuItem
 	 */
 
 	/**
-	 * @type {import("svelte/store").Writable<{x: number; y: number; items: MenuItem[]} | null>}
+	 * @type {{x: number; y: number; items: MenuItem[]} | null}
 	 */
-	let menu_items = writable(null);
+	let menu_items = $state(null);
 
 	/**
 	 * @param {number} x
@@ -20,16 +18,16 @@
 	 */
 	export function open(x, y, items) {
 		if (items.length > 0) {
-			menu_items.set({ x, y, items });
+			menu_items = { x, y, items };
 		}
 	}
 </script>
 
-{#if $menu_items}
-	<nav style="position: fixed; z-index: 5; top:{$menu_items.y}px; left:{$menu_items.x}px">
+{#if menu_items}
+	<nav style="position: fixed; z-index: 5; top:{menu_items.y}px; left:{menu_items.x}px">
 		<div class="navbar" id="navbar">
 			<ul>
-				{#each $menu_items.items as item}
+				{#each menu_items.items as item}
 					<li>
 						<button on:click={item.fn}>{item.label}</button>
 					</li>
@@ -39,7 +37,7 @@
 	</nav>
 {/if}
 
-<svelte:window on:click={() => menu_items.set(null)} />
+<svelte:window on:click={() => (menu_items = null)} />
 
 <style>
 	.navbar {

--- a/src/routes/tutorial/[slug]/filetree/File.svelte
+++ b/src/routes/tutorial/[slug]/filetree/File.svelte
@@ -2,7 +2,7 @@
 	import * as context from './context.js';
 	import Item from './Item.svelte';
 	import file_icon from '$lib/icons/file.svg';
-	import { selected_name, solution } from '../state.js';
+	import { s } from '../state.svelte.js';
 
 	/** @type {{ file: import('$lib/types').FileStub; depth: number }} */
 	let { file, depth } = $props();
@@ -11,7 +11,7 @@
 
 	let renaming = $state(false);
 
-	const can_remove = $derived(!$solution[file.name]);
+	const can_remove = $derived(!s.solution[file.name]);
 
 	/** @type {import('./ContextMenu.svelte').MenuItem[]} */
 	const actions = $derived(
@@ -42,7 +42,7 @@
 	{renaming}
 	basename={file.basename}
 	icon={file_icon}
-	selected={file.name === $selected_name}
+	selected={file.name === s.selected_name}
 	{actions}
 	on:click={() => select(file.name)}
 	on:edit={() => {

--- a/src/routes/tutorial/[slug]/filetree/File.svelte
+++ b/src/routes/tutorial/[slug]/filetree/File.svelte
@@ -4,37 +4,36 @@
 	import file_icon from '$lib/icons/file.svg';
 	import { selected_name, solution } from '../state.js';
 
-	/** @type {import('$lib/types').FileStub} */
-	export let file;
-
-	/** @type {number} */
-	export let depth;
+	/** @type {{ file: import('$lib/types').FileStub; depth: number }} */
+	let { file, depth } = $props();
 
 	const { rename, remove, select } = context.get();
 
-	let renaming = false;
+	let renaming = $state(false);
 
-	$: can_remove = !$solution[file.name];
+	const can_remove = $derived(!$solution[file.name]);
 
-	/** @type {import('./ContextMenu.svelte').MenuItems} */
-	$: actions = can_remove
-		? [
-				{
-					icon: 'rename',
-					label: 'Rename',
-					fn: () => {
-						renaming = true;
+	/** @type {import('./ContextMenu.svelte').MenuItem[]} */
+	const actions = $derived(
+		can_remove
+			? [
+					{
+						icon: 'rename',
+						label: 'Rename',
+						fn: () => {
+							renaming = true;
+						}
+					},
+					{
+						icon: 'delete',
+						label: 'Delete',
+						fn: () => {
+							remove(file);
+						}
 					}
-				},
-				{
-					icon: 'delete',
-					label: 'Delete',
-					fn: () => {
-						remove(file);
-					}
-				}
-		  ]
-		: [];
+			  ]
+			: []
+	);
 </script>
 
 <Item

--- a/src/routes/tutorial/[slug]/filetree/File.svelte
+++ b/src/routes/tutorial/[slug]/filetree/File.svelte
@@ -44,14 +44,14 @@
 	icon={file_icon}
 	selected={file.name === s.selected_name}
 	{actions}
-	on:click={() => select(file.name)}
-	on:edit={() => {
+	onclick={() => select(file.name)}
+	on_edit={() => {
 		renaming = true;
 	}}
-	on:rename={(e) => {
-		rename(file, e.detail.basename);
+	on_rename={(basename) => {
+		rename(file, basename);
 	}}
-	on:cancel={() => {
+	on_cancel={() => {
 		renaming = false;
 	}}
 />

--- a/src/routes/tutorial/[slug]/filetree/Filetree.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Filetree.svelte
@@ -1,13 +1,12 @@
 <script>
 	import { createEventDispatcher } from 'svelte';
-	import { writable } from 'svelte/store';
 	import Folder from './Folder.svelte';
 	import * as context from './context.js';
 	import Modal from '$lib/components/Modal.svelte';
-	import { files, solution, reset_files, create_directories, selected_name } from '../state.js';
+	import { reset_files, create_directories, s } from '../state.svelte.js';
 	import { afterNavigate } from '$app/navigation';
 
-	/** @type {{exercise: import('$lib/types').Exercise; mobile: boolean}} */
+	/** @type {{exercise: import('$lib/types').Exercise; mobile?: boolean}} */
 	let { exercise, mobile = false } = $props();
 
 	const dispatch = createEventDispatcher();
@@ -16,18 +15,12 @@
 
 	let modal_text = $state('');
 
-	/** @type {import('svelte/store').Writable<Record<string, boolean>>}*/
-	const collapsed = writable({});
-
-	afterNavigate(() => {
-		collapsed.set({});
-	});
-
-	context.set({
-		collapsed,
+	/** @type {context.FileTreeContext} */
+	const context_state = $state({
+		collapsed: {},
 
 		add: async (name, type) => {
-			const expected = $solution[name];
+			const expected = s.solution[name];
 
 			if (expected && type !== expected.type) {
 				modal_text = `${name.slice(exercise.scope.prefix.length)} should be a ${
@@ -43,7 +36,7 @@
 				return;
 			}
 
-			const existing = $files.find((file) => file.name === name);
+			const existing = s.files.find((file) => file.name === name);
 			if (existing) {
 				modal_text = `A ${existing.type} already exists with this name`;
 				return;
@@ -57,7 +50,7 @@
 					? { type, name, basename, text: true, contents: '' }
 					: { type, name, basename };
 
-			reset_files([...$files, ...create_directories(name, $files), file]);
+			reset_files([...s.files, ...create_directories(name, s.files), file]);
 
 			if (type === 'file') {
 				dispatch('select', { name });
@@ -67,19 +60,19 @@
 		rename: async (to_rename, new_name) => {
 			const new_full_name = to_rename.name.slice(0, -to_rename.basename.length) + new_name;
 
-			if ($files.some((f) => f.name === new_full_name)) {
+			if (s.files.some((f) => f.name === new_full_name)) {
 				modal_text = `A file or folder named ${new_full_name} already exists`;
 				return;
 			}
 
-			if (!$solution[new_full_name] && !exercise.editing_constraints.create.has(new_full_name)) {
+			if (!s.solution[new_full_name] && !exercise.editing_constraints.create.has(new_full_name)) {
 				modal_text =
 					'Only the following files and folders are allowed to be created in this exercise:\n' +
 					Array.from(exercise.editing_constraints.create).join('\n');
 				return;
 			}
 
-			if ($solution[to_rename.name] && !exercise.editing_constraints.remove.has(to_rename.name)) {
+			if (s.solution[to_rename.name] && !exercise.editing_constraints.remove.has(to_rename.name)) {
 				modal_text =
 					'Only the following files and folders are allowed to be removed in this exercise:\n' +
 					Array.from(exercise.editing_constraints.remove).join('\n');
@@ -87,19 +80,19 @@
 			}
 
 			if (to_rename.type === 'directory') {
-				for (const file of $files) {
+				for (const file of s.files) {
 					if (file.name.startsWith(to_rename.name + '/')) {
 						file.name = new_full_name + file.name.slice(to_rename.name.length);
 					}
 				}
 			}
 
-			const was_selected = $selected_name === to_rename.name;
+			const was_selected = s.selected_name === to_rename.name;
 
 			to_rename.basename = /** @type {string} */ (new_full_name.split('/').pop());
 			to_rename.name = new_full_name;
 
-			reset_files([...$files, ...create_directories(new_full_name, $files)]);
+			reset_files([...s.files, ...create_directories(new_full_name, s.files)]);
 
 			if (was_selected) {
 				dispatch('select', { name: new_full_name });
@@ -107,7 +100,7 @@
 		},
 
 		remove: async (file) => {
-			if ($solution[file.name] && !exercise.editing_constraints.remove.has(file.name)) {
+			if (s.solution[file.name] && !exercise.editing_constraints.remove.has(file.name)) {
 				modal_text =
 					'Only the following files and folders are allowed to be deleted in this tutorial chapter:\n' +
 					Array.from(exercise.editing_constraints.remove).join('\n');
@@ -117,7 +110,7 @@
 			dispatch('select', { name: null });
 
 			reset_files(
-				$files.filter((f) => {
+				s.files.filter((f) => {
 					if (f === file) return false;
 					if (f.name.startsWith(file.name + '/')) return false;
 					return true;
@@ -129,6 +122,13 @@
 			dispatch('select', { name });
 		}
 	});
+
+	afterNavigate(() => {
+		context_state.collapsed = {};
+	});
+
+	// svelte-ignore static-state-reference
+	context.set(context_state);
 
 	/** @param {import('$lib/types').Stub} file */
 	function is_deleted(file) {
@@ -162,7 +162,7 @@
 			name: '',
 			basename: exercise.scope.name
 		}}
-		contents={$files.filter((file) => !hidden.has(file.basename) && !is_deleted(file))}
+		contents={s.files.filter((file) => !hidden.has(file.basename) && !is_deleted(file))}
 	/>
 </ul>
 

--- a/src/routes/tutorial/[slug]/filetree/Filetree.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Filetree.svelte
@@ -1,15 +1,12 @@
 <script>
-	import { createEventDispatcher } from 'svelte';
 	import Folder from './Folder.svelte';
 	import * as context from './context.js';
 	import Modal from '$lib/components/Modal.svelte';
 	import { reset_files, create_directories, s } from '../state.svelte.js';
 	import { afterNavigate } from '$app/navigation';
 
-	/** @type {{exercise: import('$lib/types').Exercise; mobile?: boolean}} */
-	let { exercise, mobile = false } = $props();
-
-	const dispatch = createEventDispatcher();
+	/** @type {{exercise: import('$lib/types').Exercise; mobile?: boolean; on_select?: (name: string | null) => void;}} */
+	let { exercise, mobile = false, on_select } = $props();
 
 	const hidden = new Set(['__client.js', 'node_modules', '__delete']);
 
@@ -53,7 +50,7 @@
 			reset_files([...s.files, ...create_directories(name, s.files), file]);
 
 			if (type === 'file') {
-				dispatch('select', { name });
+				on_select?.(name);
 			}
 		},
 
@@ -95,7 +92,7 @@
 			reset_files([...s.files, ...create_directories(new_full_name, s.files)]);
 
 			if (was_selected) {
-				dispatch('select', { name: new_full_name });
+				on_select?.(new_full_name);
 			}
 		},
 
@@ -107,7 +104,7 @@
 				return;
 			}
 
-			dispatch('select', { name: null });
+			on_select?.(null);
 
 			reset_files(
 				s.files.filter((f) => {
@@ -119,7 +116,7 @@
 		},
 
 		select: (name) => {
-			dispatch('select', { name });
+			on_select?.(name);
 		}
 	});
 
@@ -142,7 +139,7 @@
 <ul
 	class="filetree"
 	class:mobile
-	on:keydown={(e) => {
+	onkeydown={(e) => {
 		if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
 			e.preventDefault();
 			const lis = Array.from(e.currentTarget.querySelectorAll('li'));
@@ -167,11 +164,11 @@
 </ul>
 
 {#if modal_text}
-	<Modal on:close={() => (modal_text = '')}>
+	<Modal onclose={() => (modal_text = '')}>
 		<div class="modal-contents">
 			<h2>This action is not allowed</h2>
 			<p>{modal_text}</p>
-			<button on:click={() => (modal_text = '')}>OK</button>
+			<button onclick={() => (modal_text = '')}>OK</button>
 		</div>
 	</Modal>
 {/if}

--- a/src/routes/tutorial/[slug]/filetree/Filetree.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Filetree.svelte
@@ -7,16 +7,14 @@
 	import { files, solution, reset_files, create_directories, selected_name } from '../state.js';
 	import { afterNavigate } from '$app/navigation';
 
-	/** @type {import('$lib/types').Exercise} */
-	export let exercise;
-
-	export let mobile = false;
+	/** @type {{exercise: import('$lib/types').Exercise; mobile: boolean}} */
+	let { exercise, mobile = false } = $props();
 
 	const dispatch = createEventDispatcher();
 
 	const hidden = new Set(['__client.js', 'node_modules', '__delete']);
 
-	let modal_text = '';
+	let modal_text = $state('');
 
 	/** @type {import('svelte/store').Writable<Record<string, boolean>>}*/
 	const collapsed = writable({});
@@ -32,7 +30,9 @@
 			const expected = $solution[name];
 
 			if (expected && type !== expected.type) {
-				modal_text = `${name.slice(exercise.scope.prefix.length)} should be a ${expected.type}, not a ${type}!`;
+				modal_text = `${name.slice(exercise.scope.prefix.length)} should be a ${
+					expected.type
+				}, not a ${type}!`;
 				return;
 			}
 
@@ -52,9 +52,10 @@
 			const basename = /** @type {string} */ (name.split('/').pop());
 
 			/** @type {import('$lib/types').Stub} */
-			const file = type === 'file'
-				? { type, name, basename, text: true, contents: '' }
-				: { type, name, basename };
+			const file =
+				type === 'file'
+					? { type, name, basename, text: true, contents: '' }
+					: { type, name, basename };
 
 			reset_files([...$files, ...create_directories(name, $files), file]);
 

--- a/src/routes/tutorial/[slug]/filetree/Folder.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Folder.svelte
@@ -115,19 +115,19 @@
 	can_rename={can_remove}
 	{renaming}
 	{actions}
-	on:click={() => {
+	onclick={() => {
 		collapsed[directory.name] = !collapsed[directory.name];
 	}}
-	on:edit={() => {
+	on_edit={() => {
 		renaming = true;
 	}}
-	on:rename={(e) => {
-		rename(directory, e.detail.basename);
+	on_rename={(basename) => {
+		rename(directory, basename);
 	}}
-	on:cancel={() => {
+	on_cancel={() => {
 		renaming = false;
 	}}
-	on:keydown={(e) => {
+	onkeydown={(e) => {
 		if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
 			collapsed[directory.name] = e.key === 'ArrowLeft';
 		}
@@ -139,10 +139,10 @@
 		<Item
 			depth={depth + 1}
 			renaming
-			on:rename={(e) => {
-				add(prefix + e.detail.basename, 'directory');
+			on_rename={(basename) => {
+				add(prefix + basename, 'directory');
 			}}
-			on:cancel={() => {
+			on_cancel={() => {
 				s.creating = null;
 			}}
 		/>
@@ -156,10 +156,10 @@
 		<Item
 			depth={depth + 1}
 			renaming
-			on:rename={(e) => {
-				add(prefix + e.detail.basename, 'file');
+			on_rename={(basename) => {
+				add(prefix + basename, 'file');
 			}}
-			on:cancel={() => {
+			on_cancel={() => {
 				s.creating = null;
 			}}
 		/>

--- a/src/routes/tutorial/[slug]/filetree/Folder.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Folder.svelte
@@ -7,107 +7,105 @@
 	import folder_open from '$lib/icons/folder-open.svg';
 	import { files, solution, creating } from '../state.js';
 
-	/** @type {import('$lib/types').DirectoryStub} */
-	export let directory;
+	/** @type {{ directory: import('$lib/types').DirectoryStub; prefix: string; depth: number; contents: Array<import('$lib/types').Stub>; }} */
+	let { directory, prefix, depth, contents } = $props();
 
-	/** @type {string} */
-	export let prefix;
-
-	/** @type {number} */
-	export let depth;
-
-	/** @type {Array<import('$lib/types').Stub>} */
-	export let contents;
-
-	let renaming = false;
+	let renaming = $state(false);
 
 	const { collapsed, rename, add, remove } = context.get();
 
-	$: segments = get_depth(prefix);
+	const segments = $derived(get_depth(prefix));
 
-	$: children = contents
-		.filter((file) => file.name.startsWith(prefix))
-		.sort((a, b) => (a.name < b.name ? -1 : 1));
-
-	$: child_directories = children.filter(
-		(child) => get_depth(child.name) === segments && child.type === 'directory'
+	const children = $derived(
+		contents
+			.filter((file) => file.name.startsWith(prefix))
+			.sort((a, b) => (a.name < b.name ? -1 : 1))
 	);
 
-	$: child_files = /** @type {import('$lib/types').FileStub[]} */ (
-		children.filter((child) => get_depth(child.name) === segments && child.type === 'file')
+	const child_directories = $derived(
+		children.filter((child) => get_depth(child.name) === segments && child.type === 'directory')
 	);
 
-	const can_create = { file: false, directory: false };
+	const child_files = $derived(
+		/** @type {import('$lib/types').FileStub[]} */ (
+			children.filter((child) => get_depth(child.name) === segments && child.type === 'file')
+		)
+	);
 
-	$: {
-		can_create.file = false;
-		can_create.directory = false;
+	const can_create = $derived(
+		(() => {
+			const can_create = { file: false, directory: false };
+			const child_prefixes = [];
 
-		const child_prefixes = [];
-
-		for (const file of $files) {
-			if (
-				file.type === 'directory' &&
-				file.name.startsWith(prefix) &&
-				get_depth(file.name) === depth + 1
-			) {
-				child_prefixes.push(file.name + '/');
+			for (const file of $files) {
+				if (
+					file.type === 'directory' &&
+					file.name.startsWith(prefix) &&
+					get_depth(file.name) === depth + 1
+				) {
+					child_prefixes.push(file.name + '/');
+				}
 			}
-		}
 
-		for (const file of Object.values($solution)) {
-			if (!file.name.startsWith(prefix)) continue;
+			for (const file of Object.values($solution)) {
+				if (!file.name.startsWith(prefix)) continue;
 
-			// if already exists in $files, bail
-			if ($files.find((f) => f.name === file.name)) continue;
+				// if already exists in $files, bail
+				if ($files.find((f) => f.name === file.name)) continue;
 
-			// if intermediate directory exists, bail
-			if (child_prefixes.some((prefix) => file.name.startsWith(prefix))) continue;
+				// if intermediate directory exists, bail
+				if (child_prefixes.some((prefix) => file.name.startsWith(prefix))) continue;
 
-			can_create[file.type] = true;
-		}
-	}
+				can_create[file.type] = true;
+			}
+
+			return can_create;
+		})()
+	);
 
 	// fake root directory has no name
-	$: can_remove = directory.name ? !$solution[directory.name] : false;
+	const can_remove = $derived(directory.name ? !$solution[directory.name] : false);
 
-	/** @type {import('./ContextMenu.svelte').MenuItem[]} */
-	$: actions = [
-		can_create.file && {
-			icon: 'file-new',
-			label: 'New file',
-			fn: () => {
-				creating.set({
-					parent: directory.name,
-					type: 'file'
-				});
-			}
-		},
-		can_create.directory && {
-			icon: 'folder-new',
-			label: 'New folder',
-			fn: () => {
-				creating.set({
-					parent: directory.name,
-					type: 'directory'
-				});
-			}
-		},
-		can_remove && {
-			icon: 'rename',
-			label: 'Rename',
-			fn: () => {
-				renaming = true;
-			}
-		},
-		can_remove && {
-			icon: 'delete',
-			label: 'Delete',
-			fn: () => {
-				remove(directory);
-			}
-		}
-	].filter(Boolean);
+	const actions = $derived(
+		/** @type {import('./ContextMenu.svelte').MenuItem[]} */ (
+			[
+				can_create.file && {
+					icon: 'file-new',
+					label: 'New file',
+					fn: () => {
+						creating.set({
+							parent: directory.name,
+							type: 'file'
+						});
+					}
+				},
+				can_create.directory && {
+					icon: 'folder-new',
+					label: 'New folder',
+					fn: () => {
+						creating.set({
+							parent: directory.name,
+							type: 'directory'
+						});
+					}
+				},
+				can_remove && {
+					icon: 'rename',
+					label: 'Rename',
+					fn: () => {
+						renaming = true;
+					}
+				},
+				can_remove && {
+					icon: 'delete',
+					label: 'Delete',
+					fn: () => {
+						remove(directory);
+					}
+				}
+			].filter(Boolean)
+		)
+	);
 </script>
 
 <Item

--- a/src/routes/tutorial/[slug]/filetree/Item.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Item.svelte
@@ -2,20 +2,26 @@
 	import { createEventDispatcher, tick } from 'svelte';
 	import { open } from './ContextMenu.svelte';
 
-	export let basename = '';
-	export let icon = '';
-	export let depth = 0;
-
-	export let selected = false;
-
-	/** @type {boolean} */
-	export let can_rename = false;
-
-	/** @type {boolean} */
-	export let renaming;
-
-	/** @type {import('./ContextMenu.svelte').MenuItem[]} */
-	export let actions = [];
+	/**
+	 * @type {{
+	 * 	basename: string;
+	 * 	icon: string;
+	 * 	depth: number;
+	 * 	selected: boolean;
+	 * 	can_rename: boolean;
+	 * 	renaming: boolean;
+	 * 	actions: import('./ContextMenu.svelte').MenuItem[]
+	 * }}
+	 */
+	let {
+		basename = '',
+		icon = '',
+		depth = 0,
+		selected = false,
+		can_rename = false,
+		renaming,
+		actions = []
+	} = $props();
 
 	const dispatch = createEventDispatcher();
 

--- a/src/routes/tutorial/[slug]/filetree/Item.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Item.svelte
@@ -4,13 +4,13 @@
 
 	/**
 	 * @type {{
-	 * 	basename: string;
-	 * 	icon: string;
-	 * 	depth: number;
-	 * 	selected: boolean;
-	 * 	can_rename: boolean;
+	 * 	basename?: string;
+	 * 	icon?: string;
+	 * 	depth?: number;
+	 * 	selected?: boolean;
+	 * 	can_rename?: boolean;
 	 * 	renaming: boolean;
-	 * 	actions: import('./ContextMenu.svelte').MenuItem[]
+	 * 	actions?: import('./ContextMenu.svelte').MenuItem[]
 	 * }}
 	 */
 	let {

--- a/src/routes/tutorial/[slug]/filetree/context.js
+++ b/src/routes/tutorial/[slug]/filetree/context.js
@@ -2,7 +2,7 @@ import { setContext, getContext } from 'svelte';
 
 /**
  * @typedef {{
- *   collapsed: import('svelte/store').Writable<Record<string, boolean>>;
+ *   collapsed: Record<string, boolean>;
  *   add: (name: string, type: 'file' | 'directory') => Promise<void>;
  *   rename: (stub: import('$lib/types').Stub, name: string) => Promise<void>;
  *   remove: (stub: import('$lib/types').Stub) => Promise<void>;


### PR DESCRIPTION
This is a POC of migrating a small but more involved codebase to Svelte 5.

## Notes

- after bumping to Svelte 5 the app worked without any changes, though it has a few small bugs (see next section)
- wanted `$derived.fn` a couple of times because of big derivations (ex: `Folder.svelte`)
- wanted `$effect.pre` to run on the server, too, when converting some `$:` statements that were not reactive assignments
- being more familiar with runes syntax now I find the result more readable. Especially the differentiation of `$derived` and `$effect` is very helpful to understand better what kind of code I'm dealing with
- most migrations are generic, having automigration will help, it's rare that a change in behavior is introduced. `$props()` is the most tedious one (but also the easiest to automigrate)
- the "synchronize from props but also update from above" situation occured in `Menu.svelte`
- the "this needs to be `$state`" warning was very helpful in converting the right variables / not forgetting it
- the "State referenced in its own scope will never update" warning was sometimes overzealous, for example when passing a proxied state to context when I know it's only the properties that are meant to be used reactively. But I think it will help greatly in other situations, so it's probably fine
- converting stores to state objects required a bit of per-case thinking because the whole object isn't reactive, only its parts are. With `writable` there was a fixed contract making you think less about this because the container was already there. I ended up moving most separate `writable`s into one big `$state` object because I don't have the "how to encapsulate it" problem then. This feels natural for state that belongs together but for primitive state you always have to think a bit how to do it. Usage-wise it didn't feel much different to stores, although doing `x.set(newValue)` feels a bit nicer compared to `container.x = newValue`, which feels hacky because you're mutating stuff all over. That could just be me though, and in a certain way it might even be good because the hackyness of modifying stuff from everywhere without hiding it behind a proper method that changes things is more obvious that way - though it isn't as easy to forbid writing to the state because there's no way to mark something as readonly for the outside but have it be regular `$state` within the same scope.
- migrating towards event attributes was straightforward. In some cases it revealed workarounds (the payload being an object with on property on it, so that you can write `e.detail.theName` to know what you're dealing with which can be simplified to just `theName`). In one case I had to add `$props()` because of event forwarding, which felt a bit more boilerplatey to write but afterwards it's much clearer what the component's in/outputs are because I can just scan for the `$props()` rune. In that instance I also had to add the `children` prop because it was receiving `<slot />` content which was a bit confusing for a moment, maybe language tools can make it more clear what's going on there. Speaking of: I found the syntax highlighting to be worse, we should maybe highlight the attributes starting with `on` differently, and we definetly should add semantic highlighting to them.

Overall the migration was pretty straightforward, with a few gotchas which depending on your app could happen more or less frequently. The new code reads better overall to me, though not really much has changed, especially in the template (which is a good thing I'd say!)

## Bugs

- SvelteKit: `afterNavigate` doesnt fire initially, because `onMount` is async now (result: editor doesn't show code contents for initial load); we need to call `flushState()` in the backwards compatibility wrapper or in SvelteKit
- folder tree: new file -> doesn't autofocus
- Svelte/SvelteSplitPane: resizing doesn't work properly. In Svelte 4, `bind:this` triggers an update that is flushed in the next tick, in Svelte 5 it's synchronous. This results in one update in Svelte 4 with height/width set but two updates in Svelte 5 with the first having no width/height set yet, resulting in a too low calculation and therefore rendering the editor too small. I don't think we can fix this in Svelte 5 due to the timings, so the fix needs to happen in SvelteSplitPane (arguably it revealed a proper bug in the library)
