### PR TITLE
Inform user to install marked for local usage

### DIFF
--- a/content/tutorial/01-svelte/06-bindings/07-textarea-inputs/README.md
+++ b/content/tutorial/01-svelte/06-bindings/07-textarea-inputs/README.md
@@ -2,6 +2,8 @@
 title: Textarea inputs
 ---
 
+Important: If following this tutorial locally, you will need to install the `marked` dependency using your package manager (e.g. `npm install marked`)
+
 The `<textarea>` element behaves similarly to a text input in Svelte — use `bind:value`:
 
 ```svelte


### PR DESCRIPTION
Apologies if this has been mentioned in the past, but I figured it was worth letting people know that they'll need to install the `marked` dependency if following the tutorial locally.

This is based on the presumption that they may not understand it's not a Svelte built-in feature.

This is not mentioned in the existing documentation.