### PR TITLE
Update README example with removed lines

### DIFF
--- a/content/tutorial/02-advanced-svelte/09-special-elements/02-svelte-component/README.md
+++ b/content/tutorial/02-advanced-svelte/09-special-elements/02-svelte-component/README.md
@@ -27,6 +27,11 @@ We _could_ do this with a sequence of `if` blocks...
 	{/each}
 </select>
 
+---{#if selected.color === 'red'}
+	<RedThing />
+{:else}
+	<p>TODO others</p>
+{/if}---
 +++<svelte:component this={selected.component} />+++
 ```
 


### PR DESCRIPTION
In the example on [https://learn.svelte.dev/tutorial/svelte-component](https://learn.svelte.dev/tutorial/svelte-component), the example should have the explicit removal of code
<img width="1194" alt="CleanShot 2024-02-12 at 18 28 14@2x" src="https://github.com/sveltejs/learn.svelte.dev/assets/21699995/c6d3480a-0a10-4e53-adc6-cc680a516d7e">
