### PR TITLE
fix(02-advanced-svelte/07-composition): fix invisible `paper.svg` background

### DIFF
--- a/content/tutorial/02-advanced-svelte/07-composition/01-slots/app-a/src/lib/paper.svg
+++ b/content/tutorial/02-advanced-svelte/07-composition/01-slots/app-a/src/lib/paper.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 350 200">
 	<filter id='paper' x='0%' y='0%' width='100%' height='100%'>
 		<feTurbulence type="fractalNoise" baseFrequency="0.04" numOctaves="5" result="noise" />
-		<feDiffuseLighting in="noise" lighting-color="white" surfaceScale="3" result="diffLight">
+		<feDiffuseLighting in="noise" lighting-color="white" surfaceScale="1" result="diffLight">
 			<feDistantLight elevation="60" />
 		</feDiffuseLighting>
 	</filter>
 
-	<rect x="0" y="0" width="100%" height="100%" filter="url(#paper)" fill="none" />
+	<rect x="0" y="0" width="100%" height="100%" filter="url(#paper)" fill="white" />
 </svg>

--- a/content/tutorial/02-advanced-svelte/07-composition/02-named-slots/app-a/src/lib/paper.svg
+++ b/content/tutorial/02-advanced-svelte/07-composition/02-named-slots/app-a/src/lib/paper.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 350 200">
 	<filter id='paper' x='0%' y='0%' width='100%' height='100%'>
 		<feTurbulence type="fractalNoise" baseFrequency="0.04" numOctaves="5" result="noise" />
-		<feDiffuseLighting in="noise" lighting-color="white" surfaceScale="3" result="diffLight">
+		<feDiffuseLighting in="noise" lighting-color="white" surfaceScale="1" result="diffLight">
 			<feDistantLight elevation="60" />
 		</feDiffuseLighting>
 	</filter>

--- a/content/tutorial/02-advanced-svelte/07-composition/03-slot-fallbacks/app-a/src/lib/paper.svg
+++ b/content/tutorial/02-advanced-svelte/07-composition/03-slot-fallbacks/app-a/src/lib/paper.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 350 200">
 	<filter id='paper' x='0%' y='0%' width='100%' height='100%'>
 		<feTurbulence type="fractalNoise" baseFrequency="0.04" numOctaves="5" result="noise" />
-		<feDiffuseLighting in="noise" lighting-color="white" surfaceScale="3" result="diffLight">
+		<feDiffuseLighting in="noise" lighting-color="white" surfaceScale="1" result="diffLight">
 			<feDistantLight elevation="60" />
 		</feDiffuseLighting>
 	</filter>
 
-	<rect x="0" y="0" width="100%" height="100%" filter="url(#paper)" fill="none" />
+	<rect x="0" y="0" width="100%" height="100%" filter="url(#paper)" fill="white" />
 </svg>


### PR DESCRIPTION
Caught this while going through the tutorial. When used as a background image, not including a fill will make the svg invisible, this commit adds the fill so the example works properly. Have also adjusted the noise `surfaceScale` so the effect is a bit more subtle.

Tested in local dev environment to ensure this works as intended.