### PR TITLE
fix(svelt:events): ensure m prop is synced

### DIFF
--- a/content/tutorial/01-svelte/05-events/01-dom-events/app-a/src/lib/App.svelte
+++ b/content/tutorial/01-svelte/05-events/01-dom-events/app-a/src/lib/App.svelte
@@ -4,6 +4,7 @@
 	function handleMove(event) {
 		m.x = event.clientX;
 		m.y = event.clientY;
+		m = m;
 	}
 </script>
 

--- a/content/tutorial/01-svelte/05-events/01-dom-events/app-b/src/lib/App.svelte
+++ b/content/tutorial/01-svelte/05-events/01-dom-events/app-b/src/lib/App.svelte
@@ -4,6 +4,7 @@
 	function handleMove(event) {
 		m.x = event.clientX;
 		m.y = event.clientY;
+		m = m;
 	}
 </script>
 


### PR DESCRIPTION
# Description

After solving the tutorial exercise of section Part 1. BasicSvelt > Events > DOM Events as requested by the tutorial, the pointer position was not being updated at the DOM. This was happening because the m object was not being assigned after changes, this PR solved it.

> Disclaim: Opted for `m = m;` instead of whole object assignment because the next section already suggests it