### PR TITLE
Update README.md

### DIFF
--- a/content/tutorial/02-advanced-svelte/09-special-elements/01-svelte-self/README.md
+++ b/content/tutorial/02-advanced-svelte/09-special-elements/01-svelte-self/README.md
@@ -9,9 +9,9 @@ It's useful for things like this folder tree view, where folders can contain _ot
 ```svelte
 /// file: Folder.svelte
 {#if file.files}
-	<Folder {...file}/>
+	<Folder {...file} />
 {:else}
-	<File {...file}/>
+	<File {...file} />
 {/if}
 ```
 
@@ -20,8 +20,8 @@ It's useful for things like this folder tree view, where folders can contain _ot
 ```svelte
 /// file: Folder.svelte
 {#if file.files}
-	+++<svelte:self {...file}/>+++
+	+++<svelte:self {...file} />+++
 {:else}
-	<File {...file}/>
+	<File {...file} />
 {/if}
 ```


### PR DESCRIPTION
Svelte tutorial expects space before closing the tag in order for user's answer to be correct.