### PR TITLE
fix(06-bindings/05-group-inputs): fixed typo

### DIFF
--- a/content/tutorial/01-svelte/06-bindings/05-group-inputs/app-a/src/lib/App.svelte
+++ b/content/tutorial/01-svelte/06-bindings/05-group-inputs/app-a/src/lib/App.svelte
@@ -36,7 +36,7 @@
 {#if flavours.length === 0}
 	<p>Please select at least one flavour</p>
 {:else if flavours.length > scoops}
-	<p>Can't order more flavours than scoops!</p>
+	<p>Can't order more flavours than {scoops} {scoops === 1 ? 'scoop' : 'scoops'}!</p>
 {:else}
 	<p>
 		You ordered {scoops} {scoops === 1 ? 'scoop' : 'scoops'}


### PR DESCRIPTION
Found this while going through the Tutorial

The line displays:
"Can't order more flavours than scoops!"

Which doesn't make much grammatical sense.

Added `{scoops} {scoops === 1 ? 'scoop' : 'scoops'}` so it will display the number of scoops correctly.

"Can't order more flavours than 1 scoop!"
"Can't order more flavours than 2 scoops!"

Which was probably the expected text to be displayed.