### PR TITLE
fix: set refresh icon background to transparent

### DIFF
--- a/src/routes/tutorial/[slug]/Chrome.svelte
+++ b/src/routes/tutorial/[slug]/Chrome.svelte
@@ -96,6 +96,7 @@
 		top: 0;
 		background-image: url($lib/icons/refresh.svg);
 		transition: 0.2s ease-out;
+		background-color: transparent;
 	}
 
 	.reload:active::after {


### PR DESCRIPTION
Small fix, this has been bugging me for a while.

When the refresh button rotates the edge of the box can be seen rotating with it every. single. time. The background is set to transparent now so this doesn't happen anymore.
![image](https://github.com/sveltejs/learn.svelte.dev/assets/105564371/bb5663b1-5b8a-4c61-a01d-733075e0affa)

Sorry for the insignificant pull request, this thing has just been driving me crazy.