### PR TITLE
Update README.md

### DIFF
--- a/content/tutorial/01-svelte/03-props/03-spread-props/README.md
+++ b/content/tutorial/01-svelte/03-props/03-spread-props/README.md
@@ -23,4 +23,4 @@ We _could_ fix it by adding the `version` prop...
 <PackageInfo +++{...pkg}+++ />
 ```
 
-> Conversely, if you need to reference all the props that were passed into a component, including ones that weren't declared with `export`, you can do so by accessing `$$props` directly. It's not generally recommended, as it's difficult for Svelte to optimise, but it's useful in rare cases.
+> Conversely, if you need to reference all the props that were passed into a component, including ones that weren't declared with `export`, you can do so by accessing `$props` directly. It's not generally recommended, as it's difficult for Svelte to optimise, but it's useful in rare cases.


### PR DESCRIPTION
Removed additional `$` sign from `$$props` in Note if need to reference all the props that were passed into a component.