### PR TITLE
docs: fix minor object update example

### DIFF
--- a/content/tutorial/01-svelte/02-reactivity/04-updating-arrays-and-objects/README.md
+++ b/content/tutorial/01-svelte/02-reactivity/04-updating-arrays-and-objects/README.md
@@ -43,4 +43,4 @@ const foo = obj.foo;
 foo.bar = 2;
 ```
 
-...won't trigger reactivity on `obj.foo.bar`, unless you follow it up with `obj = obj`.
+...won't trigger reactivity on `obj.foo.bar`, unless you follow it up with `obj.foo = foo`.


### PR DESCRIPTION
The existing `obj = obj` assignment wouldn't work in the given example as `obj` is declared as `const`.

Could also be changed to declare `obj` with `let` instead.