### PR TITLE
Update paper.svg filler for 7.01 & 7.03

### DIFF
--- a/content/tutorial/02-advanced-svelte/07-composition/01-slots/app-a/src/lib/paper.svg
+++ b/content/tutorial/02-advanced-svelte/07-composition/01-slots/app-a/src/lib/paper.svg
@@ -6,5 +6,5 @@
 		</feDiffuseLighting>
 	</filter>
 
-	<rect x="0" y="0" width="100%" height="100%" filter="url(#paper)" fill="none" />
+	<rect x="0" y="0" width="100%" height="100%" filter="url(#paper)" fill="white" />
 </svg>

--- a/content/tutorial/02-advanced-svelte/07-composition/03-slot-fallbacks/app-a/src/lib/paper.svg
+++ b/content/tutorial/02-advanced-svelte/07-composition/03-slot-fallbacks/app-a/src/lib/paper.svg
@@ -6,5 +6,5 @@
 		</feDiffuseLighting>
 	</filter>
 
-	<rect x="0" y="0" width="100%" height="100%" filter="url(#paper)" fill="none" />
+	<rect x="0" y="0" width="100%" height="100%" filter="url(#paper)" fill="white" />
 </svg>


### PR DESCRIPTION
as was done in #502  for tutorial exercises 7.02. With `fill="none"`, the business card paper background is not rendered. This PR changes to `fill="white"` in 7.01 and 7.03.

(Really enjoying the tutorial and Svelte in general so far. Thanks for all your work).