### PR TITLE
Fix ZIP Code typo in slots examples

### DIFF
--- a/content/tutorial/02-advanced-svelte/07-composition/02-named-slots/app-a/src/lib/App.svelte
+++ b/content/tutorial/02-advanced-svelte/07-composition/02-named-slots/app-a/src/lib/App.svelte
@@ -14,7 +14,7 @@
 			<small>Mergers and Aquisitions</small>
 		</span>
 		
-		<span slot="address">358 Exchange Place, New York, N.Y. 100099 fax 212 555 6390 telex 10 4534</span>
+		<span slot="address">358 Exchange Place, New York, N.Y. 10099 fax 212 555 6390 telex 10 4534</span>
 	</Card>
 </main>
 

--- a/content/tutorial/02-advanced-svelte/07-composition/02-named-slots/app-b/src/lib/App.svelte
+++ b/content/tutorial/02-advanced-svelte/07-composition/02-named-slots/app-b/src/lib/App.svelte
@@ -14,7 +14,7 @@
 			<small>Mergers and Aquisitions</small>
 		</span>
 		
-		<span slot="address">358 Exchange Place, New York, N.Y. 100099 fax 212 555 6390 telex 10 4534</span>
+		<span slot="address">358 Exchange Place, New York, N.Y. 10099 fax 212 555 6390 telex 10 4534</span>
 	</Card>
 </main>
 

--- a/content/tutorial/02-advanced-svelte/07-composition/03-slot-fallbacks/app-a/src/lib/App.svelte
+++ b/content/tutorial/02-advanced-svelte/07-composition/03-slot-fallbacks/app-a/src/lib/App.svelte
@@ -14,7 +14,7 @@
 			<small>Mergers and Aquisitions</small>
 		</span>
 		
-		<span slot="address">358 Exchange Place, New York, N.Y. 100099 fax 212 555 6390 telex 10 4534</span>
+		<span slot="address">358 Exchange Place, New York, N.Y. 10099 fax 212 555 6390 telex 10 4534</span>
 	</Card>
 
 	<Card />


### PR DESCRIPTION
The slot examples have the ZIP Code on the business card as `100099`, which is too many digits for a ZIP Code and not the one on the card in the film. This PR corrects them to `10099`.