### PR TITLE
chore: squelch warnings

### DIFF
--- a/src/routes/tutorial/[slug]/filetree/Filetree.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Filetree.svelte
@@ -138,6 +138,7 @@
 	}
 </script>
 
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <ul
 	class="filetree"
 	class:mobile

--- a/src/routes/tutorial/[slug]/filetree/Item.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Item.svelte
@@ -39,6 +39,7 @@
 	}
 </script>
 
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <li
 	aria-current={selected ? 'true' : undefined}
 	style="--depth: {depth}; --icon: url('{icon}');"


### PR DESCRIPTION
I think these warnings are safe to squelch because they fall under 'progressive enhancement'