### PR TITLE
tidy up types

### DIFF
--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -78,3 +78,14 @@ export interface EditingConstraints {
 	create: Set<string>;
 	remove: Set<string>;
 }
+
+// TODO replace with `Warning` from `svelte/compiler`
+export interface Warning {
+	code: string;
+	start: { line: number; column: number; character: number };
+	end: { line: number; column: number; character: number };
+	pos: number;
+	filename: string;
+	frame: string;
+	message: string;
+}

--- a/src/routes/tutorial/[slug]/adapter.js
+++ b/src/routes/tutorial/[slug]/adapter.js
@@ -15,7 +15,7 @@ export const error = writable(null);
 /** @type {import('svelte/store').Writable<string[]>} */
 export const logs = writable([]);
 
-/** @type {import('svelte/store').Writable<Record<string, import('./state').CompilerWarning[]>>} */
+/** @type {import('svelte/store').Writable<Record<string, import('$lib/types').Warning[]>>} */
 export const warnings = writable({});
 
 /** @type {Promise<import('$lib/types').Adapter>} */

--- a/src/routes/tutorial/[slug]/state.js
+++ b/src/routes/tutorial/[slug]/state.js
@@ -6,19 +6,6 @@ import * as adapter from './adapter.js';
  * @typedef {import('svelte/store').Writable<T>} Writable<T>
  */
 
-// TODO would be nice if svelte exported this type (maybe it does already?)
-/**
- * @typedef {{
- *   code: string;
- *   start: { line: number, column: number, character: number };
- *   end: { line: number, column: number, character: number };
- *   pos: number;
- *   filename: string;
- *   frame: string;
- *   message: string;
- * }} CompilerWarning
- */
-
 /** @type {Writable<import('$lib/types').Stub[]>} */
 export const files = writable([]);
 


### PR DESCRIPTION
move `CompilerWarning` out of a typedef and into `types.d.ts`, plus some drive-by Prettier fixes