### PR TITLE
chore: fix type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"prettier-plugin-svelte": "^3.0.3",
 		"shiki-twoslash": "^3.1.2",
 		"svelte": "^4.2.0",
-		"svelte-check": "^3.5.1",
+		"svelte-check": "^3.7.1",
 		"tiny-glob": "^0.2.9",
 		"typescript": "^5.3.3",
 		"vite": "^5.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,8 +149,8 @@ devDependencies:
     specifier: ^4.2.0
     version: 4.2.10
   svelte-check:
-    specifier: ^3.5.1
-    version: 3.6.4(svelte@4.2.10)
+    specifier: ^3.7.1
+    version: 3.7.1(svelte@4.2.10)
   tiny-glob:
     specifier: ^0.2.9
     version: 0.2.9
@@ -2159,6 +2159,7 @@ packages:
 
   /rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
     dependencies:
       glob: 7.2.3
@@ -2326,8 +2327,8 @@ packages:
     resolution: {integrity: sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==}
     dev: false
 
-  /svelte-check@3.6.4(svelte@4.2.10):
-    resolution: {integrity: sha512-mY/dqucqm46p72M8yZmn81WPZx9mN6uuw8UVfR3ZKQeLxQg5HDGO3HHm5AZuWZPYNMLJ+TRMn+TeN53HfQ/vsw==}
+  /svelte-check@3.7.1(svelte@4.2.10):
+    resolution: {integrity: sha512-U4uJoLCzmz2o2U33c7mPDJNhRYX/DNFV11XTUDlFxaKLsO7P+40gvJHMPpoRfa24jqZfST4/G9fGNcUGMO8NAQ==}
     hasBin: true
     peerDependencies:
       svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
@@ -2427,7 +2428,7 @@ packages:
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
-      magic-string: 0.30.7
+      magic-string: 0.30.10
       sorcery: 0.11.0
       strip-indent: 3.0.0
       svelte: 4.2.10

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -89,3 +89,9 @@ export interface Warning {
 	frame: string;
 	message: string;
 }
+
+export interface MenuItem {
+	icon: string;
+	label: string;
+	fn: () => void;
+}

--- a/src/routes/tutorial/[slug]/filetree/ContextMenu.svelte
+++ b/src/routes/tutorial/[slug]/filetree/ContextMenu.svelte
@@ -5,18 +5,14 @@
 	import { writable } from 'svelte/store';
 
 	/**
-	 * @typedef {{ icon: string; label: string; fn: () => void }} MenuItem
-	 */
-
-	/**
-	 * @type {import("svelte/store").Writable<{x: number; y: number; items: MenuItem[]} | null>}
+	 * @type {import("svelte/store").Writable<{x: number; y: number; items: import('$lib/types').MenuItem[]} | null>}
 	 */
 	let menu_items = writable(null);
 
 	/**
 	 * @param {number} x
 	 * @param {number} y
-	 * @param {MenuItem[]} items
+	 * @param {import('$lib/types').MenuItem[]} items
 	 */
 	export function open(x, y, items) {
 		if (items.length > 0) {

--- a/src/routes/tutorial/[slug]/filetree/File.svelte
+++ b/src/routes/tutorial/[slug]/filetree/File.svelte
@@ -16,7 +16,7 @@
 
 	$: can_remove = !$solution[file.name];
 
-	/** @type {import('./ContextMenu.svelte').MenuItems} */
+	/** @type {import('$lib/types').MenuItem[]} */
 	$: actions = can_remove
 		? [
 				{

--- a/src/routes/tutorial/[slug]/filetree/Filetree.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Filetree.svelte
@@ -146,7 +146,7 @@
 		if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
 			e.preventDefault();
 			const lis = Array.from(e.currentTarget.querySelectorAll('li'));
-			const focused = lis.findIndex((li) => li.contains(e.target));
+			const focused = lis.findIndex((li) => li.contains(/** @type {HTMLElement} */ (e.target)));
 
 			const d = e.key === 'ArrowUp' ? -1 : +1;
 

--- a/src/routes/tutorial/[slug]/filetree/Folder.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Folder.svelte
@@ -33,8 +33,11 @@
 		(child) => get_depth(child.name) === segments && child.type === 'directory'
 	);
 
-	$: child_files = /** @type {import('$lib/types').FileStub[]} */ (
-		children.filter((child) => get_depth(child.name) === segments && child.type === 'file')
+	// prettier-ignore
+	$: child_files = (
+		/** @type {import('$lib/types').FileStub[]} */ (
+			children.filter((child) => get_depth(child.name) === segments && child.type === 'file')
+		)
 	);
 
 	const can_create = { file: false, directory: false };
@@ -71,43 +74,45 @@
 	// fake root directory has no name
 	$: can_remove = directory.name ? !$solution[directory.name] : false;
 
-	/** @type {import('./ContextMenu.svelte').MenuItem[]} */
-	$: actions = [
-		can_create.file && {
-			icon: 'file-new',
-			label: 'New file',
-			fn: () => {
-				creating.set({
-					parent: directory.name,
-					type: 'file'
-				});
+	// prettier-ignore
+	$: actions = (
+		/** @type {import('$lib/types').MenuItem[]} */ ([
+			can_create.file && {
+				icon: 'file-new',
+				label: 'New file',
+				fn: () => {
+					creating.set({
+						parent: directory.name,
+						type: 'file'
+					});
+				}
+			},
+			can_create.directory && {
+				icon: 'folder-new',
+				label: 'New folder',
+				fn: () => {
+					creating.set({
+						parent: directory.name,
+						type: 'directory'
+					});
+				}
+			},
+			can_remove && {
+				icon: 'rename',
+				label: 'Rename',
+				fn: () => {
+					renaming = true;
+				}
+			},
+			can_remove && {
+				icon: 'delete',
+				label: 'Delete',
+				fn: () => {
+					remove(directory);
+				}
 			}
-		},
-		can_create.directory && {
-			icon: 'folder-new',
-			label: 'New folder',
-			fn: () => {
-				creating.set({
-					parent: directory.name,
-					type: 'directory'
-				});
-			}
-		},
-		can_remove && {
-			icon: 'rename',
-			label: 'Rename',
-			fn: () => {
-				renaming = true;
-			}
-		},
-		can_remove && {
-			icon: 'delete',
-			label: 'Delete',
-			fn: () => {
-				remove(directory);
-			}
-		}
-	].filter(Boolean);
+		].filter(Boolean))
+	);
 </script>
 
 <Item

--- a/src/routes/tutorial/[slug]/filetree/Item.svelte
+++ b/src/routes/tutorial/[slug]/filetree/Item.svelte
@@ -14,7 +14,7 @@
 	/** @type {boolean} */
 	export let renaming;
 
-	/** @type {import('./ContextMenu.svelte').MenuItem[]} */
+	/** @type {import('$lib/types').MenuItem[]} */
 	export let actions = [];
 
 	const dispatch = createEventDispatcher();


### PR DESCRIPTION
needed to add `prettier-ignore` comments because otherwise it fights with JSDoc. would probably be easier to just use TS, but will save that for the Svelte 5 rewrite