### PR TITLE
chore: enable Vercel speed insights on site

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"@replit/codemirror-vim": "^6.0.14",
 		"@rich_harris/svelte-split-pane": "^1.1.3",
 		"@sveltejs/repl": "^0.6.0",
+		"@vercel/speed-insights": "^1.0.0",
 		"@webcontainer/api": "^1.1.5",
 		"adm-zip": "^0.5.10",
 		"ansi-to-html": "^0.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ dependencies:
   '@sveltejs/repl':
     specifier: ^0.6.0
     version: 0.6.0(@codemirror/lang-html@6.4.8)(@codemirror/search@6.5.6)(@lezer/common@1.2.1)(@lezer/javascript@1.4.13)(@lezer/lr@1.4.0)(@sveltejs/kit@2.5.9)(svelte@4.2.10)
+  '@vercel/speed-insights':
+    specifier: ^1.0.0
+    version: 1.0.11(@sveltejs/kit@2.5.9)(svelte@4.2.10)
   '@webcontainer/api':
     specifier: ^1.1.5
     version: 1.1.9
@@ -1226,6 +1229,34 @@ packages:
       - encoding
       - supports-color
     dev: true
+
+  /@vercel/speed-insights@1.0.11(@sveltejs/kit@2.5.9)(svelte@4.2.10):
+    resolution: {integrity: sha512-l9hzSNmJvb2Yqpgd/BzpiT0J0aQDdtqxOf3Xm+iW4PICxVvhY1ef7Otdx4GXI+88dVkws57qMzXiShz19gXzSQ==}
+    requiresBuild: true
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19
+      svelte: ^4
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+    dependencies:
+      '@sveltejs/kit': 2.5.9(@sveltejs/vite-plugin-svelte@3.1.0)(svelte@4.2.10)(vite@5.2.11)
+      svelte: 4.2.10
+    dev: false
 
   /@webcontainer/api@1.1.9:
     resolution: {integrity: sha512-Sp6PV0K9D/3f8fSbCubqhfmBFH8XbngZCBOCF+aExyGqnz2etmw+KYvbQ/JxYvYX5KPaSxM+asFQwoP2RHl5cg==}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,8 +5,11 @@
 	import { Icon, Shell } from '@sveltejs/site-kit/components';
 	import { Nav, Separator } from '@sveltejs/site-kit/nav';
 	import { Search, SearchBox } from '@sveltejs/site-kit/search';
+	import { injectSpeedInsights } from '@vercel/speed-insights/sveltekit';
 	import '@sveltejs/site-kit/styles/index.css';
 	import '../app.css';
+
+	injectSpeedInsights();
 
 	export let data;
 </script>


### PR DESCRIPTION
privacy-compliant way to track performance metrics on our sites