### PR TITLE
Fix spin function syntax for Svelte tutorial

### DIFF
--- a/content/tutorial/02-advanced-svelte/02-transitions/04-custom-css-transitions/README.md
+++ b/content/tutorial/02-advanced-svelte/02-transitions/04-custom-css-transitions/README.md
@@ -53,7 +53,7 @@ We can get a lot more creative though. Let's make something truly gratuitous:
 	function spin(node, { duration }) {
 		return {
 			duration,
-			css: t => +++{
+			css: (t) => +++{
 				const eased = elasticOut(t);
 
 				return `
@@ -62,7 +62,7 @@ We can get a lot more creative though. Let's make something truly gratuitous:
 						${Math.trunc(t * 360)},
 						${Math.min(100, 1000 * (1 - t))}%,
 						${Math.min(50, 500 * (1 - t))}%
-					);`
+					);`;
 			}+++
 		};
 	}


### PR DESCRIPTION
Corrected arrow function syntax to include missing parenthesis around the "t" parameter and added semicolon after the last backtick in returned CSS string. The auto-grader expects both.