### PR TITLE
Update else-blocks example so that it makes sense when {count} is 0 or 10.

### DIFF
--- a/content/tutorial/01-svelte/04-logic/02-else-blocks/app-b/src/lib/App.svelte
+++ b/content/tutorial/01-svelte/04-logic/02-else-blocks/app-b/src/lib/App.svelte
@@ -14,5 +14,5 @@
 {#if count > 10}
 	<p>{count} is greater than 10</p>
 {:else}
-	<p>{count} is between 0 and 10</p>
+	<p>{count} is less than 11</p>
 {/if}


### PR DESCRIPTION
Currently the <p> that is rendered by the else statement is false when count is 0 and 10. It says "0 is between 0 and 10" and when count reaches 10 it says "10 is between 0 and 10". The proposed change results in true statements for all numbers that are not greater than 10.