### PR TITLE
Deleting code duplication, re-arranging head elements and quick fixes

### DIFF
--- a/content/tutorial/common/src/app.html
+++ b/content/tutorial/common/src/app.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta charset="utf-8">

--- a/content/tutorial/common/src/app.html
+++ b/content/tutorial/common/src/app.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="color-scheme" content="dark light" />
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" href="%sveltekit.assets%/favicon.png">
+		<meta name="color-scheme" content="dark light">
 		%sveltekit.head%
 
 		<style>

--- a/src/app.html
+++ b/src/app.html
@@ -1,17 +1,17 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="color-scheme" content="dark light" />
-		<meta name="theme-color" media="(prefers-color-scheme: light)" content="#fff" />
-		<meta name="theme-color" media="(prefers-color-scheme: dark)" content="#2e2e2e" />
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width">
+		<link rel="icon" href="%sveltekit.assets%/favicon.png">
+		<meta name="color-scheme" content="dark light">
+		<meta name="theme-color" media="(prefers-color-scheme: light)" content="#fff">
+		<meta name="theme-color" media="(prefers-color-scheme: dark)" content="#2e2e2e">
 		<meta
 			name="description"
 			content="Learn Svelte and SvelteKit with an interactive browser-based tutorial"
-		/>
-		<link rel="manifest" href="/manifest.json" />
+		>
+		<link rel="manifest" href="/manifest.json">
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/routes/tutorial/[slug]/+page.svelte
+++ b/src/routes/tutorial/[slug]/+page.svelte
@@ -143,18 +143,14 @@
 <svelte:head>
 	<title>{data.exercise.chapter.title} / {data.exercise.title} • Svelte Tutorial</title>
 
-	<meta name="twitter:title" content="{data.exercise.title} • Svelte Tutorial" />
-	<meta name="twitter:card" content="summary" />
-	<meta name="twitter:site" content="@sveltejs" />
-	<meta name="twitter:creator" content="@sveltejs" />
-	<meta name="twitter:image" content="https://svelte.dev/images/twitter-thumbnail.jpg" />
-	<meta property="twitter:domain" content="learn.svelte.dev" />
-	<meta property="twitter:url" content="https://learn.svelte.dev" />
-
-	<meta property="og:title" content="{data.exercise.title} • Svelte Tutorial" />
-	<meta property="og:url" content="https://learn.svelte.dev" />
-	<meta property="og:type" content="website" />
-	<meta property="og:image" content="https://svelte.dev/images/twitter-thumbnail.jpg" />
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:site" content="@sveltejs">
+	<meta name="twitter:creator" content="@sveltejs">
+	<meta property="twitter:domain" content="learn.svelte.dev">
+	<meta property="og:url" content="https://learn.svelte.dev">
+	<meta property="og:type" content="website">
+	<meta property="og:title" content="{data.exercise.title} • Svelte Tutorial">
+	<meta property="og:image" content="https://svelte.dev/images/twitter-thumbnail.jpg">
 </svelte:head>
 
 <svelte:window


### PR DESCRIPTION
1. Deleting unnecessary "twitter:*" meta elements to reduce code duplication, which "og:*" meta elements can be used as fallback.
2. Re-arranging head elements in order to make parsing faster (theorically).
3. Changing self-closing elements typing from "/>" to ">".
4. Changing uppercase doctype declaration to lowercase ("DOCTYPE" to "doctype"), in favor of saving 4bytes when compressing via gzip or brotli.

## Resources
### Twitter and OG meta elements:
1. https://developer.x.com/en/docs/twitter-for-websites/cards/guides/getting-started
2. https://developer.x.com/en/docs/twitter-for-websites/cards/overview/markup

### HEAD arrangment
https://github.com/rviscomi/capo.js

---

There is a problem that I didn't fix (couldn't) which is there is a `<style>` tag renders before `<meta charset="utf-8">` which may be bad, because it's suggested to do that:
> Every page must declare a character encoding of UTF-8, using either the charset meta tag or the Content-Type HTTP response header. When the meta tag is used, it must be discoverable within the first 1024 bytes of the document.