### PR TITLE
use a better alternative to 'chain'

### DIFF
--- a/content/tutorial/01-svelte/05-events/03-event-modifiers/README.md
+++ b/content/tutorial/01-svelte/05-events/03-event-modifiers/README.md
@@ -22,4 +22,4 @@ The full list of modifiers:
 - `self` — only trigger handler if event.target is the element itself
 - `trusted` — only trigger handler if `event.isTrusted` is `true`, meaning the event was triggered by a user action rather than because some JavaScript called `element.dispatchEvent(...)`
 
-You can chain modifiers together, e.g. `on:click|once|capture={...}`.
+You can use multiple modifiers together, e.g. `on:click|once|capture={...}`.


### PR DESCRIPTION
From the [original docs](https://learn.svelte.dev/tutorial/event-modifiers):
> You can chain modifiers together, e.g. 
> `on:click|once|capture={...}.`

The term "chain" may imply a sequential approach, which might not clearly convey the concept of applying multiple event modifiers simultaneously. 

I believe we can use a better alternative.
> You can user multiple modifiers together, e.g. 
> `on:click|once|capture={...}.`