### PR TITLE
fix: a11y warning of "02-advanced-svelte/04-actions/01-actions/app-a(b)" and "02-advanced-svelte/05-bindings/07-component-this/app-a(b)"

### DIFF
--- a/content/tutorial/02-advanced-svelte/04-actions/01-actions/app-a/src/lib/App.svelte
+++ b/content/tutorial/02-advanced-svelte/04-actions/01-actions/app-a/src/lib/App.svelte
@@ -14,6 +14,8 @@
 	{#if showMenu}
 		<div
 			class="modal-background"
+			role="menu"
+			tabindex="-1"
 			on:click|self={() => showMenu = false}
 			on:keydown={(e) => {
 				if (e.key === 'Escape') showMenu = false;

--- a/content/tutorial/02-advanced-svelte/04-actions/01-actions/app-b/src/lib/App.svelte
+++ b/content/tutorial/02-advanced-svelte/04-actions/01-actions/app-b/src/lib/App.svelte
@@ -15,6 +15,8 @@
 	{#if showMenu}
 		<div
 			class="modal-background"
+			role="menu"
+			tabindex="-1"
 			on:click|self={() => showMenu = false}
 			on:keydown={(e) => {
 				if (e.key === 'Escape') showMenu = false;

--- a/content/tutorial/02-advanced-svelte/05-bindings/07-component-this/app-a/src/lib/App.svelte
+++ b/content/tutorial/02-advanced-svelte/05-bindings/07-component-this/app-a/src/lib/App.svelte
@@ -15,6 +15,8 @@
 	{#if showMenu}
 		<div
 			class="modal-background"
+			role="menu"
+			tabindex="-1"
 			on:click|self={() => showMenu = false}
 			on:keydown={(e) => {
 				if (e.key === 'Escape') showMenu = false;

--- a/content/tutorial/02-advanced-svelte/05-bindings/07-component-this/app-b/src/lib/App.svelte
+++ b/content/tutorial/02-advanced-svelte/05-bindings/07-component-this/app-b/src/lib/App.svelte
@@ -17,6 +17,8 @@
 	{#if showMenu}
 		<div
 			class="modal-background"
+			role="menu"
+			tabindex="-1"
 			on:click|self={() => showMenu = false}
 			on:keydown={(e) => {
 				if (e.key === 'Escape') showMenu = false;


### PR DESCRIPTION
Remove this warning. Not sure if there is a role more suitable than `menu`.

<img width="1463" alt="截圖 2024-08-27 上午9 44 05" src="https://github.com/user-attachments/assets/63f2c28a-331c-4741-987e-5660a132666f">