### PR TITLE
updated README for part1/reactivity/updating-arrays-and-objects

### DIFF
--- a/content/tutorial/01-svelte/02-reactivity/04-updating-arrays-and-objects/README.md
+++ b/content/tutorial/01-svelte/02-reactivity/04-updating-arrays-and-objects/README.md
@@ -38,8 +38,8 @@ A simple rule of thumb: the name of the updated variable must appear on the left
 
 ```js
 /// no-file
-const obj = { foo: { bar: 1 } };
-const foo = obj.foo;
+let obj = { foo: { bar: 1 } };
+let foo = obj.foo;
 foo.bar = 2;
 ```
 


### PR DESCRIPTION
Part 1/Reactivity/Updating arrays and objects has an example
```js
/// no-file
const obj = { foo: { bar: 1 } };
const foo = obj.foo;
foo.bar = 2;
```
Stating that this "...won't trigger reactivity on `obj.foo.bar`, unless you follow it up with `obj = obj`."

Which is true. But either way when an ignorant beginner like me reaches this example, they would struggle with it, as using `obj = obj` would present them with an error as such `/src/lib/App.svelte:13:2 You are assigning to a const`. So I changed it to:

```js
/// no-file
let obj = { foo: { bar: 1 } };
let foo = obj.foo;
foo.bar = 2;
```
If this is I request this PR be merged.
