### PR TITLE
Remove unused CSS class

### DIFF
--- a/content/tutorial/02-advanced-svelte/06-classes-and-styles/03-styles/app-b/src/lib/App.svelte
+++ b/content/tutorial/02-advanced-svelte/06-classes-and-styles/03-styles/app-b/src/lib/App.svelte
@@ -47,10 +47,6 @@
 		cursor: pointer;
 	}
 
-	.card.flipped {
-		transform: rotateY(0);
-	}
-
 	.front, .back {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
Fix linter error: Unused CSS selector ".card.flipped"

To see this, go to [https://learn.svelte.dev/tutorial/styles](https://learn.svelte.dev/tutorial/styles) click "solve" and you'll see in the editor, .card.flipped isn't used.